### PR TITLE
CIF-326 - Check that mandatory fields are returned by the API implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "globalinstall": "npm install -g lerna@2.0.0-rc.5",
     "generate-cov-html": "$(npm bin)/nyc report --reporter=html",
     "test": "$(npm bin)/lerna run lint && npm run test-cov && npm run generate-cov-html",
-    "test-cov": "XUNIT_FILE=test-results-xunit.xml $(npm bin)/nyc $(npm bin)/mocha test/**/*Test.js -R xunit-file && $(npm bin)/nyc report --reporter=lcov",
+    "test-cov": "XUNIT_FILE=test/results/unit/results.xml $(npm bin)/nyc $(npm bin)/mocha test/**/*Test.js -R xunit-file && $(npm bin)/nyc report --reporter=lcov",
     "unit": "$(npm bin)/mocha test/**/*Test.js",
-    "test-it": "XUNIT_FILE=test-results-it-xunit.xml $(npm bin)/mocha test/**/*IT.js -R xunit-file"
+    "test-it": "XUNIT_FILE=test/results/integration/results.xml $(npm bin)/mocha test/**/*IT.js -R xunit-file"
   }
 }

--- a/src/carts/CartMapper.js
+++ b/src/carts/CartMapper.js
@@ -96,10 +96,13 @@ class CartMapper {
             if (Math.abs(magentoCart.totals.base_grand_total) > 0) {
                 cart.grossTotalPrice = new Price(magentoCart.totals.base_grand_total * 100, magentoCart.totals.quote_currency_code);
             }
-            //do not map when 0
+            // Required field
             if (Math.abs(magentoCart.totals.subtotal_incl_tax) > 0) {
                 cart.totalProductPrice = new Price(magentoCart.totals.subtotal_incl_tax * 100, magentoCart.totals.quote_currency_code);
+            } else {
+                cart.totalProductPrice = new Price(0, magentoCart.totals.quote_currency_code);
             }
+
             //do not map when 0
             if (Math.abs(magentoCart.totals.tax_amount) > 0) {
                 cart.cartTaxInfo = new TaxInfo(magentoCart.totals.tax_amount * 100);
@@ -201,6 +204,10 @@ class CartMapper {
         let v = new ProductVariant();
         //variant name is the sku so will fill it from the chained action
         v.sku = item.sku;
+
+        // TODO: Get actual value from backend
+        v.available = true;
+
         return v;
     }
 

--- a/src/carts/PaymentMapper.js
+++ b/src/carts/PaymentMapper.js
@@ -46,6 +46,7 @@ class PaymentMapper {
         }
 
         let ccifPayment = new Payment();
+        ccifPayment.id = magentoPayment.method;
         ccifPayment.method = magentoPayment.method;
 
         return ccifPayment;

--- a/src/carts/package-lock.json
+++ b/src/carts/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@adobe/commerce-cif-common": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.15.tgz",
-			"integrity": "sha512-tRzdh7jdeZuIZ2rlrWjy+3+PVxXD+d5D41Z8q9yVhu6IKRm2GqNsDqOVnvEIPlzalXmdsy7wphDSxV6cbR28kQ==",
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.17.tgz",
+			"integrity": "sha512-TBHa7JRupiypXzoc5JILZLnQIoQhfdE0mV/cmb1kTb4UElT/41GC2yVZF5LQ5NQOUwOfMGtZ+8ckQClnOjdvYQ==",
 			"requires": {
 				"http-status-codes": "1.1.6"
 			}

--- a/src/carts/package.json
+++ b/src/carts/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@adobe/commerce-cif-magento-common": "0.0.1",
-    "@adobe/commerce-cif-common": "0.1.15",
+    "@adobe/commerce-cif-common": "0.1.17",
     "@adobe/commerce-cif-model": "0.1.123"
   },
   "devDependencies": {

--- a/src/categories/package-lock.json
+++ b/src/categories/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@adobe/commerce-cif-common": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.15.tgz",
-			"integrity": "sha512-tRzdh7jdeZuIZ2rlrWjy+3+PVxXD+d5D41Z8q9yVhu6IKRm2GqNsDqOVnvEIPlzalXmdsy7wphDSxV6cbR28kQ==",
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.17.tgz",
+			"integrity": "sha512-TBHa7JRupiypXzoc5JILZLnQIoQhfdE0mV/cmb1kTb4UElT/41GC2yVZF5LQ5NQOUwOfMGtZ+8ckQClnOjdvYQ==",
 			"requires": {
 				"http-status-codes": "1.1.6"
 			}

--- a/src/categories/package.json
+++ b/src/categories/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@adobe/commerce-cif-magento-common": "0.0.1",
-    "@adobe/commerce-cif-common": "0.1.15",
+    "@adobe/commerce-cif-common": "0.1.17",
     "@adobe/commerce-cif-model": "0.1.123"
   },
   "devDependencies": {

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@adobe/commerce-cif-common": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.15.tgz",
-			"integrity": "sha512-tRzdh7jdeZuIZ2rlrWjy+3+PVxXD+d5D41Z8q9yVhu6IKRm2GqNsDqOVnvEIPlzalXmdsy7wphDSxV6cbR28kQ==",
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.17.tgz",
+			"integrity": "sha512-TBHa7JRupiypXzoc5JILZLnQIoQhfdE0mV/cmb1kTb4UElT/41GC2yVZF5LQ5NQOUwOfMGtZ+8ckQClnOjdvYQ==",
 			"requires": {
 				"http-status-codes": "1.1.6"
 			}

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/adobe/commerce-cif-magento.git"
   },
   "dependencies": {
-    "@adobe/commerce-cif-common": "0.1.15",
+    "@adobe/commerce-cif-common": "0.1.17",
     "@adobe/commerce-cif-model": "0.1.123",
     "request": "2.87.0",
     "request-promise-native": "1.0.5"

--- a/src/customer/package-lock.json
+++ b/src/customer/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@adobe/commerce-cif-common": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.15.tgz",
-			"integrity": "sha512-tRzdh7jdeZuIZ2rlrWjy+3+PVxXD+d5D41Z8q9yVhu6IKRm2GqNsDqOVnvEIPlzalXmdsy7wphDSxV6cbR28kQ==",
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.17.tgz",
+			"integrity": "sha512-TBHa7JRupiypXzoc5JILZLnQIoQhfdE0mV/cmb1kTb4UElT/41GC2yVZF5LQ5NQOUwOfMGtZ+8ckQClnOjdvYQ==",
 			"requires": {
 				"http-status-codes": "1.1.6"
 			}

--- a/src/customer/package.json
+++ b/src/customer/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/adobe/commerce-cif-magento.git"
   },
   "dependencies": {
-    "@adobe/commerce-cif-common": "0.1.15",
+    "@adobe/commerce-cif-common": "0.1.17",
     "@adobe/commerce-cif-magento-common": "0.0.1",
     "@adobe/commerce-cif-model": "0.1.123"
   },

--- a/src/orders/package-lock.json
+++ b/src/orders/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@adobe/commerce-cif-common": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.15.tgz",
-			"integrity": "sha512-tRzdh7jdeZuIZ2rlrWjy+3+PVxXD+d5D41Z8q9yVhu6IKRm2GqNsDqOVnvEIPlzalXmdsy7wphDSxV6cbR28kQ==",
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.17.tgz",
+			"integrity": "sha512-TBHa7JRupiypXzoc5JILZLnQIoQhfdE0mV/cmb1kTb4UElT/41GC2yVZF5LQ5NQOUwOfMGtZ+8ckQClnOjdvYQ==",
 			"requires": {
 				"http-status-codes": "1.1.6"
 			}

--- a/src/orders/package.json
+++ b/src/orders/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@adobe/commerce-cif-magento-common": "0.0.1",
-    "@adobe/commerce-cif-common": "0.1.15",
+    "@adobe/commerce-cif-common": "0.1.17",
     "@adobe/commerce-cif-model": "0.1.123"
   },
   "devDependencies": {

--- a/src/products/ProductMapper.js
+++ b/src/products/ProductMapper.js
@@ -140,6 +140,9 @@ class ProductMapper {
     _mapProductVariant(product, variant) {
         let v = new ProductVariant(variant.sku); // not a mistake, we use the SKU for the ID
         this._mapProductData(v, variant);
+
+        // TODO: Get actual value from backend
+        v.available = true;
         
         if (product.configurable_options) {
             v.attributes = this._addConfigurableOptions(product, variant);

--- a/src/products/package-lock.json
+++ b/src/products/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@adobe/commerce-cif-common": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.15.tgz",
-			"integrity": "sha512-tRzdh7jdeZuIZ2rlrWjy+3+PVxXD+d5D41Z8q9yVhu6IKRm2GqNsDqOVnvEIPlzalXmdsy7wphDSxV6cbR28kQ==",
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.17.tgz",
+			"integrity": "sha512-TBHa7JRupiypXzoc5JILZLnQIoQhfdE0mV/cmb1kTb4UElT/41GC2yVZF5LQ5NQOUwOfMGtZ+8ckQClnOjdvYQ==",
 			"requires": {
 				"http-status-codes": "1.1.6"
 			}

--- a/src/products/package.json
+++ b/src/products/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@adobe/commerce-cif-magento-common": "0.0.1",
-    "@adobe/commerce-cif-common": "0.1.15",
+    "@adobe/commerce-cif-common": "0.1.17",
     "@adobe/commerce-cif-model": "0.1.123",
     "handlebars": "4.0.11",
     "request": "2.87.0",

--- a/test/carts/CartMapperTest.js
+++ b/test/carts/CartMapperTest.js
@@ -156,9 +156,11 @@ describe('Magento CartMapper', () => {
 
             assert.isUndefined(mappedCart.netTotalPrice);
             assert.isUndefined(mappedCart.grossTotalPrice);
-            assert.isUndefined(mappedCart.totalProductPrice);
             assert.isUndefined(mappedCart.cartTaxInfo);
             assert.isUndefined(mappedCart.shippingInfo);
+
+            // Required field
+            assert.isDefined(mappedCart.totalProductPrice);
         });
 
         it('succeeds if cart has no billingAddress', () => {

--- a/test/carts/PaymentMapperTest.js
+++ b/test/carts/PaymentMapperTest.js
@@ -41,6 +41,7 @@ describe('Magento PaymentMapper', () => {
 
             let expected = new Payment();
             expected.method = "creditcard";
+            expected.id = expected.method;
 
             assert.deepEqual(cifPayment, expected);
         });

--- a/test/carts/deleteCartEntryIT.js
+++ b/test/carts/deleteCartEntryIT.js
@@ -18,9 +18,9 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
-
 chai.use(chaiHttp);
 
 
@@ -82,6 +82,8 @@ describe('magento deleteCartEntry', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.CREATED);
+                    requiredFields.verifyCart(res.body);
+
                     // Verify that two products are in the cart
                     expect(res.body.cartEntries).to.have.lengthOf(2);
                 
@@ -97,18 +99,16 @@ describe('magento deleteCartEntry', function() {
                         .query({
                             id: cartId,
                             cartEntryId: cartEntryIdSecond
-                        })
-                        .then(function(res) {
-                            expect(res).to.be.json;
-                            expect(res).to.have.status(HttpStatus.OK);
-
-                            // Verify that only original product is still in the cart
-                            expect(res.body.cartEntries).to.have.lengthOf(1);
-                            expect(res.body.cartEntries[0].id).to.equal(cartEntryId);
-                        })
-                        .catch(function(err) {
-                            throw err;
                         });
+                })
+                .then(function(res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyCart(res.body);
+
+                    // Verify that only original product is still in the cart
+                    expect(res.body.cartEntries).to.have.lengthOf(1);
+                    expect(res.body.cartEntries[0].id).to.equal(cartEntryId);
                 })
                 .catch(function(err) {
                     throw err;
@@ -117,20 +117,21 @@ describe('magento deleteCartEntry', function() {
     
         it('removes an entry from a cart', function() {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'deleteCartEntry')
-                    .query({
-                        id: cartId,
-                        cartEntryId: cartEntryId
-                    })
-                    .then(function(res) {
-                        expect(res).to.be.json;
-                        expect(res).to.have.status(HttpStatus.OK);
-                    
-                        expect(res.body.cartEntries).to.have.lengthOf(0);
-                    })
-                    .catch(function(err) {
-                        throw err;
-                    });
+                .post(env.cartsPackage + 'deleteCartEntry')
+                .query({
+                    id: cartId,
+                    cartEntryId: cartEntryId
+                })
+                .then(function(res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+                
+                    requiredFields.verifyCart(res.body);
+                    expect(res.body.cartEntries).to.have.lengthOf(0);
+                })
+                .catch(function(err) {
+                    throw err;
+                });
         });
         
         it('returns a 400 error for an invalid entry id', function() {
@@ -142,6 +143,8 @@ describe('magento deleteCartEntry', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -154,6 +157,8 @@ describe('magento deleteCartEntry', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -166,6 +171,8 @@ describe('magento deleteCartEntry', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -174,6 +181,8 @@ describe('magento deleteCartEntry', function() {
                 .post(env.cartsPackage + 'deleteCartEntry')
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 

--- a/test/carts/deletePaymentIT.js
+++ b/test/carts/deletePaymentIT.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 
@@ -37,10 +38,12 @@ describe('Magento deletePayment', function () {
 
         it('returns 501 error', function () {
             return chai.request(env.openwhiskEndpoint)
-                       .post(env.cartsPackage + 'deletePayment')
-                       .catch(function (err) {
-                           expect(err.response).to.have.status(HttpStatus.NOT_IMPLEMENTED);
-                       });
+                .post(env.cartsPackage + 'deletePayment')
+                .catch(function (err) {
+                    expect(err.response).to.have.status(HttpStatus.NOT_IMPLEMENTED);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
 
     });

--- a/test/carts/deleteShippingAddressIT.js
+++ b/test/carts/deleteShippingAddressIT.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 
@@ -36,10 +37,12 @@ describe('Magento deleteShippingAddress', function () {
 
         it('returns 501 error', function () {
             return chai.request(env.openwhiskEndpoint)
-                       .post(env.cartsPackage + 'deleteShippingAddress')
-                       .catch(function (err) {
-                           expect(err.response).to.have.status(HttpStatus.NOT_IMPLEMENTED);
-                       });
+                .post(env.cartsPackage + 'deleteShippingAddress')
+                .catch(function (err) {
+                    expect(err.response).to.have.status(HttpStatus.NOT_IMPLEMENTED);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
     });
 });

--- a/test/carts/deleteShippingMethodIT.js
+++ b/test/carts/deleteShippingMethodIT.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 
@@ -36,10 +37,12 @@ describe('Magento deleteShippingMethod', function () {
 
         it('returns 501 error', function () {
             return chai.request(env.openwhiskEndpoint)
-                       .post(env.cartsPackage + 'deleteShippingMethod')
-                       .catch(function (err) {
-                           expect(err.response).to.have.status(HttpStatus.NOT_IMPLEMENTED);
-                       });
+                .post(env.cartsPackage + 'deleteShippingMethod')
+                .catch(function (err) {
+                    expect(err.response).to.have.status(HttpStatus.NOT_IMPLEMENTED);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
     });
 });

--- a/test/carts/getCartIT.js
+++ b/test/carts/getCartIT.js
@@ -67,6 +67,7 @@ describe('magento getCart', function() {
         it('returns a cart for a valid cart id', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getCart')
+                .set({'Cache-Control': 'no-cache'})
                 .query({id: cartId})
                 .then(function (res) {
                     expect(res).to.be.json;
@@ -93,6 +94,7 @@ describe('magento getCart', function() {
         it('returns a 400 error for a missing id parameter', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getCart')
+                .set({'Cache-Control': 'no-cache'})
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
                     expect(err.response).to.be.json;
@@ -103,6 +105,7 @@ describe('magento getCart', function() {
         it('returns a 404 error for a non existent cart', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getCart')
+                .set({'Cache-Control': 'no-cache'})
                 .query({id: 'does-not-exist'})
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);

--- a/test/carts/getCartIT.js
+++ b/test/carts/getCartIT.js
@@ -67,7 +67,7 @@ describe('magento getCart', function() {
         it('returns a cart for a valid cart id', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getCart')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({id: cartId})
                 .then(function (res) {
                     expect(res).to.be.json;
@@ -94,7 +94,7 @@ describe('magento getCart', function() {
         it('returns a 400 error for a missing id parameter', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getCart')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
                     expect(err.response).to.be.json;
@@ -105,7 +105,7 @@ describe('magento getCart', function() {
         it('returns a 404 error for a non existent cart', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getCart')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({id: 'does-not-exist'})
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);

--- a/test/carts/getCartIT.js
+++ b/test/carts/getCartIT.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 
@@ -72,24 +73,17 @@ describe('magento getCart', function() {
                     expect(res).to.have.status(HttpStatus.OK);
 
                     // Verify structure
+                    requiredFields.verifyCart(res.body);
                     expect(res.body).to.have.own.property('lastModifiedDate');
                     //TODO update when TOTAL is added
-                    expect(res.body).to.have.own.property('totalProductPrice');
-                    expect(res.body).to.have.own.property('id');
                     expect(res.body.id).to.equal(cartId);
                     expect(res.body).to.have.own.property('createdDate');
-                    expect(res.body).to.have.own.property('cartEntries');
                     expect(res.body.cartEntries).to.have.lengthOf(1);
 
                     const entry = res.body.cartEntries[0];
-                    expect(entry).to.have.own.property('quantity');
                     expect(entry.quantity).to.equal(2);
-                    expect(entry).to.have.own.property('unitPrice');
-                    expect(entry).to.have.own.property('productVariant');
                     expect(entry.productVariant).to.have.own.property('id');
                     expect(entry.productVariant.sku).to.equal(productVariantId);
-                    expect(entry).to.have.own.property('id');
-                    expect(entry).to.have.own.property('cartEntryPrice');
                 })
                 .catch(function(err) {
                     throw err;
@@ -101,6 +95,8 @@ describe('magento getCart', function() {
                 .get(env.cartsPackage + 'getCart')
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -110,6 +106,8 @@ describe('magento getCart', function() {
                 .query({id: 'does-not-exist'})
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
         

--- a/test/carts/getShippingMethodsIT.js
+++ b/test/carts/getShippingMethodsIT.js
@@ -83,6 +83,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
 
                     return chai.request(env.openwhiskEndpoint)
                         .get(env.cartsPackage + 'getShippingMethods')
+                        .set({'Cache-Control': 'no-cache'})
                         .query({ id: cartId });
                 })
                 .then(function (res) {
@@ -104,6 +105,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
         it('returns a 400 error for a cart without shipping address', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getShippingMethods')
+                .set({'Cache-Control': 'no-cache'})
                 .query({ id: cartId })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
@@ -113,6 +115,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
         it('returns a 400 error for a missing id parameter', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getShippingMethods')
+                .set({'Cache-Control': 'no-cache'})
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
                     expect(err.response).to.be.json;
@@ -123,6 +126,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
         it('returns a 404 error for a non existent shopping cart', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getShippingMethods')
+                .set({'Cache-Control': 'no-cache'})
                 .query({ id: 'does-not-exist' })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);

--- a/test/carts/getShippingMethodsIT.js
+++ b/test/carts/getShippingMethodsIT.js
@@ -17,6 +17,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 
@@ -91,8 +92,8 @@ describe('Magento getShippingMethodsIT for a cart', function () {
                     // Verify shipping methods structure
                     expect(res.body).to.be.an('array');
                     res.body.forEach(shippingMethod => {
-                        expect(shippingMethod).to.have.all
-                            .keys('id', 'name', 'description', 'price');
+                        requiredFields.verifyShippingMethod(shippingMethod);
+                        expect(shippingMethod).to.have.own.property('description');
                     });
                 })
                 .catch(function (err) {
@@ -114,6 +115,8 @@ describe('Magento getShippingMethodsIT for a cart', function () {
                 .get(env.cartsPackage + 'getShippingMethods')
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -123,6 +126,8 @@ describe('Magento getShippingMethodsIT for a cart', function () {
                 .query({ id: 'does-not-exist' })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
     });

--- a/test/carts/getShippingMethodsIT.js
+++ b/test/carts/getShippingMethodsIT.js
@@ -83,7 +83,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
 
                     return chai.request(env.openwhiskEndpoint)
                         .get(env.cartsPackage + 'getShippingMethods')
-                        .set({'Cache-Control': 'no-cache'})
+                        .set('Cache-Control', 'no-cache')
                         .query({ id: cartId });
                 })
                 .then(function (res) {
@@ -105,7 +105,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
         it('returns a 400 error for a cart without shipping address', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getShippingMethods')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({ id: cartId })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
@@ -115,7 +115,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
         it('returns a 400 error for a missing id parameter', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getShippingMethods')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
                     expect(err.response).to.be.json;
@@ -126,7 +126,7 @@ describe('Magento getShippingMethodsIT for a cart', function () {
         it('returns a 404 error for a non existent shopping cart', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.cartsPackage + 'getShippingMethods')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({ id: 'does-not-exist' })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);

--- a/test/carts/postCartEntryIT.js
+++ b/test/carts/postCartEntryIT.js
@@ -19,6 +19,7 @@ const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
 const expect = chai.expect;
+const requiredFields = require('../lib/requiredFields');
 
 chai.use(chaiHttp);
 
@@ -80,7 +81,7 @@ describe('magento postCartEntry', function() {
                             .query({
                                 id: cartId,
                                 cartEntryId: cartEntryIdSecond
-                            })
+                            });
                     }).then(function (res) {
                         expect(res).to.be.json;
                         expect(res).to.have.status(HttpStatus.OK);
@@ -101,13 +102,10 @@ describe('magento postCartEntry', function() {
                     expect(res.headers).to.have.property('location');
 
                     // Verify structure
-                    expect(res.body).to.have.own.property('id');
+                    requiredFields.verifyCart(res.body);
                     expect(res.body.id).to.not.be.empty;
                     expect(res.body).to.have.own.property('lastModifiedDate');
-                    //an empty cart should have no price
-                    expect(res.body).to.not.have.property('totalProductPrice');
                     expect(res.body).to.have.own.property('createdDate');
-                    expect(res.body).to.have.own.property('cartEntries');
                     expect(res.body.cartEntries).to.have.lengthOf(0);
                 })
                 .catch(function(err) {
@@ -130,12 +128,10 @@ describe('magento postCartEntry', function() {
                     expect(res.headers).to.have.property('location');
 
                     // Verify structure
-                    expect(res.body).to.have.own.property('id');
+                    requiredFields.verifyCart(res.body);
                     expect(res.body.id).to.equal(cartId);
                     expect(res.body).to.have.own.property('lastModifiedDate');
-                    expect(res.body).to.have.own.property('totalProductPrice');
                     expect(res.body).to.have.own.property('createdDate');
-                    expect(res.body).to.have.own.property('cartEntries');
                     expect(res.body.cartEntries).to.have.lengthOf(2);
                     cartEntryIdSecond = res.body.cartEntries[1].id;
                     // Verify that product was added
@@ -167,23 +163,16 @@ describe('magento postCartEntry', function() {
                     expect(res.headers).to.have.property('location');
 
                     // Verify structure
-                    expect(res.body).to.have.own.property('id');
+                    requiredFields.verifyCart(res.body);
                     expect(res.body.id).to.not.be.empty;
                     expect(res.body).to.have.own.property('lastModifiedDate');
-                    expect(res.body).to.have.own.property('totalProductPrice');
                     expect(res.body).to.have.own.property('createdDate');
-                    expect(res.body).to.have.own.property('cartEntries');
                     expect(res.body.cartEntries).to.have.lengthOf(1);
 
                     // Verify entry structure
                     const entry = res.body.cartEntries[0];
-                    expect(entry).to.have.own.property('id');
-                    expect(entry).to.have.own.property('quantity');
                     expect(entry.quantity).to.equal(2);
-                    expect(entry).to.have.own.property('productVariant');
                     expect(entry.productVariant.sku).to.equal(productVariantId);
-                    expect(entry).to.have.own.property('cartEntryPrice');
-                    
                 })
                 .catch(function(err) {
                     throw err;
@@ -198,6 +187,8 @@ describe('magento postCartEntry', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -211,6 +202,8 @@ describe('magento postCartEntry', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -224,6 +217,8 @@ describe('magento postCartEntry', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         })
 
@@ -237,6 +232,8 @@ describe('magento postCartEntry', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -245,6 +242,8 @@ describe('magento postCartEntry', function() {
                 .post(env.cartsPackage + 'postCartEntry')
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 

--- a/test/carts/postShippingMethodIT.js
+++ b/test/carts/postShippingMethodIT.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 
@@ -63,20 +64,20 @@ describe('Magento postShippingMethod', function () {
 
         after(function () {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'deleteCartEntry')
-                    .query({
-                        id: cartId,
-                        cartEntryId: cartEntryId
-                    })
-                    .then(function (res) {
-                        expect(res).to.be.json;
-                        expect(res).to.have.status(HttpStatus.OK);
+                .post(env.cartsPackage + 'deleteCartEntry')
+                .query({
+                    id: cartId,
+                    cartEntryId: cartEntryId
+                })
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
 
-                        expect(res.body.cartEntries).to.have.lengthOf(0);
-                    })
-                    .catch(function (err) {
-                        throw err;
-                    });
+                    expect(res.body.cartEntries).to.have.lengthOf(0);
+                })
+                .catch(function (err) {
+                    throw err;
+                });
         });
 
         it('returns 404 for updating the shipping method of non existing cart', function () {
@@ -88,6 +89,8 @@ describe('Magento postShippingMethod', function () {
                 })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -99,6 +102,8 @@ describe('Magento postShippingMethod', function () {
                 })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -111,6 +116,8 @@ describe('Magento postShippingMethod', function () {
                 })
                 .catch(function (err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
 
@@ -140,10 +147,9 @@ describe('Magento postShippingMethod', function () {
                     // Verify cart shipping info
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyCart(res.body);
                     expect(res.body).to.have.property('shippingInfo');
-                    expect(res.body.shippingInfo).to.have.property('id');
-                    expect(res.body.shippingInfo).to.have.property('name');
-                    expect(res.body.shippingInfo).to.have.property('price');
+                    requiredFields.verifyShippingInfo(res.body.shippingInfo);
                 });
         });
     });

--- a/test/carts/putCartEntryIT.js
+++ b/test/carts/putCartEntryIT.js
@@ -19,6 +19,7 @@ const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
 const expect = chai.expect;
+const requiredFields = require('../lib/requiredFields');
 
 chai.use(chaiHttp);
 
@@ -42,25 +43,25 @@ describe('magento putCartEntry', function () {
         /** Create cart. */
         before(function () {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'postCartEntry')
-                    .query({
-                        currency: 'USD',
-                        quantity: 2,
-                        productVariantId: productVariantId
-                    })
-                    .then(function (res) {
-                        expect(res).to.be.json;
-                        expect(res).to.have.status(HttpStatus.CREATED);
-                        
-                        // Store cart id
-                        cartId = res.body.id;
-                        
-                        // Store cart entry id
-                        cartEntryId = res.body.cartEntries[0].id;
-                    })
-                    .catch(function (err) {
-                        throw err;
-                    });
+                .post(env.cartsPackage + 'postCartEntry')
+                .query({
+                    currency: 'USD',
+                    quantity: 2,
+                    productVariantId: productVariantId
+                })
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.CREATED);
+                    
+                    // Store cart id
+                    cartId = res.body.id;
+                    
+                    // Store cart entry id
+                    cartEntryId = res.body.cartEntries[0].id;
+                })
+                .catch(function (err) {
+                    throw err;
+                });
         });
         
         /** Delete cart entry. */
@@ -71,98 +72,104 @@ describe('magento putCartEntry', function () {
         it('updates the quantity of a cart entry to a new value', function () {
             const newQuantity = 15;
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'putCartEntry')
-                    .query({
-                        quantity: newQuantity,
-                        id: cartId,
-                        cartEntryId: cartEntryId
-                    })
-                    .then(function (res) {
-                        expect(res).to.be.json;
-                        expect(res).to.have.status(HttpStatus.OK);
-                        
-                        // Verify cart content
-                        expect(res.body.cartEntries).to.have.lengthOf(1);
-                        expect(res.body.cartEntries[0].id).to.equal(cartEntryId);
-                        expect(res.body.cartEntries[0].quantity).to.equal(newQuantity);
-                        
-                        // Verify structure
-                        expect(res.body).to.have.own.property('id');
-                        expect(res.body.id).to.equal(cartId);
-                        expect(res.body).to.have.own.property('lastModifiedDate');
-                        expect(res.body).to.have.own.property('totalProductPrice');
-                        expect(res.body).to.have.own.property('createdDate');
-                        expect(res.body).to.have.own.property('cartEntries');
-                    })
-                    .catch(function (err) {
-                        throw err;
-                    });
+                .post(env.cartsPackage + 'putCartEntry')
+                .query({
+                    quantity: newQuantity,
+                    id: cartId,
+                    cartEntryId: cartEntryId
+                })
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+
+                    // Verify structure
+                    requiredFields.verifyCart(res.body);
+                    expect(res.body.id).to.equal(cartId);
+                    expect(res.body).to.have.own.property('lastModifiedDate');
+                    expect(res.body).to.have.own.property('createdDate');
+
+                    // Verify cart content
+                    expect(res.body.cartEntries).to.have.lengthOf(1);
+                    expect(res.body.cartEntries[0].id).to.equal(cartEntryId);
+                    expect(res.body.cartEntries[0].quantity).to.equal(newQuantity);
+                })
+                .catch(function (err) {
+                    throw err;
+                });
         });
 
         it('returns a 400 error for setting an invalid quantity', function () {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'putCartEntry')
-                    .query({
-                        quantity: -100,
-                        id: cartId,
-                        cartEntryId: cartEntryId
-                    })
-                    .catch(function (err) {
-                        expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
-                    });
+                .post(env.cartsPackage + 'putCartEntry')
+                .query({
+                    quantity: -100,
+                    id: cartId,
+                    cartEntryId: cartEntryId
+                })
+                .catch(function (err) {
+                    expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
 
         it('removes a cart entry from the cart by setting its quantity to 0', function () {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'putCartEntry')
-                    .query({
-                        quantity: 0,
-                        id: cartId,
-                        cartEntryId: cartEntryId
-                    })
-                    .then(function (res) {
-                        expect(res).to.be.json;
-                        expect(res).to.have.status(HttpStatus.OK);
-                        
-                        expect(res.body.cartEntries).to.have.lengthOf(0);
-                    })
-                    .catch(function (err) {
-                        throw err;
-                    });
+                .post(env.cartsPackage + 'putCartEntry')
+                .query({
+                    quantity: 0,
+                    id: cartId,
+                    cartEntryId: cartEntryId
+                })
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyCart(res.body);
+                    expect(res.body.cartEntries).to.have.lengthOf(0);
+                })
+                .catch(function (err) {
+                    throw err;
+                });
         });
         
         it('returns a 404 error for updating a non existent cart entry', function () {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'putCartEntry')
-                    .query({
-                        quantity: 1,
-                        id: cartId,
-                        cartEntryId: 'does-not-exist'
-                    })
-                    .catch(function (err) {
-                        expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
-                    });
+                .post(env.cartsPackage + 'putCartEntry')
+                .query({
+                    quantity: 1,
+                    id: cartId,
+                    cartEntryId: 'does-not-exist'
+                })
+                .catch(function (err) {
+                    expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
         
         it('returns a 404 error for updating an entry of a non existent cart', function () {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'putCartEntry')
-                    .query({
-                        quantity: 1,
-                        id: 'does-not-exist',
-                        cartEntryId: cartEntryId
-                    })
-                    .catch(function (err) {
-                        expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
-                    });
+                .post(env.cartsPackage + 'putCartEntry')
+                .query({
+                    quantity: 1,
+                    id: 'does-not-exist',
+                    cartEntryId: cartEntryId
+                })
+                .catch(function (err) {
+                    expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
         
         it('returns a 400 error for missing parameters', function () {
             return chai.request(env.openwhiskEndpoint)
-                    .post(env.cartsPackage + 'putCartEntry')
-                    .catch(function (err) {
-                        expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
-                    });
+                .post(env.cartsPackage + 'putCartEntry')
+                .catch(function (err) {
+                    expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
         
     });

--- a/test/categories/getCategoriesIT.js
+++ b/test/categories/getCategoriesIT.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
 const categoriesConfig = require('../lib/config').categoriesConfig;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 chai.use(require('chai-sorted'));
@@ -59,11 +60,13 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(21);
                     expect(res.body.results).to.have.lengthOf(3);
 
                     // Verify structure
                     for(let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
                         expect(category).to.have.own.property('subCategories');
                         for(let subCategory of category.subCategories) {
                             expect(subCategory).to.have.own.property('parentCategories');
@@ -81,16 +84,17 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(21);
                     expect(res.body.results).to.have.lengthOf(21);
 
                     // Verify structure
                     for(let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
                         expect(category).to.not.have.own.property('subCategories');
                     }
                 });
         });
-
 
         it('returns a single category', function() {
             const categoryId = MEN_CATEGORY_ID;
@@ -105,9 +109,9 @@ describe('magento getCategories', function() {
 
                     // Verify structure
                     const category = res.body;
+                    requiredFields.verifyCategory(category);
                     expect(category).to.have.own.property('name');
                     expect(category.name).to.equal('Men');
-                    expect(category).to.have.own.property('id');
                     expect(category).to.have.own.property('lastModifiedDate');
                     expect(category).to.have.own.property('createdDate');
                 });
@@ -123,11 +127,13 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(3);
                     expect(res.body.results).to.have.lengthOf(3);
 
                     // Verify structure
                     for(let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
                         expect(category).to.not.have.own.property('subCategories');
                     }
                 });
@@ -144,6 +150,10 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
+                    for (let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
+                    }
 
                     // Verfiy sorting
                     const names = res.body.results.map(r => r.name);
@@ -162,9 +172,11 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
 
                     // Verify sorting of subcategories
                     for(let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
                         const subnames = category.subCategories.map(r => r.name);
                         expect(subnames).to.be.descending;
                     }
@@ -182,8 +194,13 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
-                    const names = res.body.results.map(r => r.name);
+                    requiredFields.verifyPagedResponse(res.body);
+                    for (let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
+                    }
+
                     // Verfiy sorting
+                    const names = res.body.results.map(r => r.name);
                     expect(names).to.be.descending;
                 });
         });
@@ -200,10 +217,14 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.offset).to.equal(10);
                     expect(res.body.count).to.equal(5);
                     expect(res.body.total).to.equal(24);
                     expect(res.body.results).to.have.lengthOf(5);
+                    for (let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
+                    }
                 });
         });
 
@@ -219,27 +240,43 @@ describe('magento getCategories', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.offset).to.equal(14);
                     expect(res.body.count).to.equal(7);
                     expect(res.body.total).to.equal(24);
                     expect(res.body.results).to.have.lengthOf(7);
+                    for (let category of res.body.results) {
+                        requiredFields.verifyCategory(category);
+                    }
                 });
         });
 
         it('returns a 400 error for invalid paging parameters', function () {
-            const promise = chai.request(env.openwhiskEndpoint)
+            return chai.request(env.openwhiskEndpoint)
                 .get(`${env.categoriesPackage}getCategories`)
-                .query({ limit: -7 });
-            return expect(promise, 'Getting categories with invalid paging parameter should return BAD_REQUEST')
-                .to.eventually.be.rejected.and.have.property('status', HttpStatus.BAD_REQUEST);
+                .query({ limit: -7 })
+                .then(function() {
+                    chai.assert.fail();
+                })
+                .catch(function(err) {
+                    expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
 
         it('returns a 404 error for a non existent category', function () {
-            const promise = chai.request(env.openwhiskEndpoint)
+            return chai.request(env.openwhiskEndpoint)
                 .get(`${env.categoriesPackage}getCategories`)
-                .query({ id: '999999999999999' });
-            return expect(promise, 'Getting a category by id which does not exist should return NOT_FOUND')
-                .to.eventually.be.rejected.and.have.property('status', HttpStatus.NOT_FOUND);
+                .query({ id: '999999999999999' })
+                .then(function() {
+                    chai.assert.fail();
+                })
+                .catch(function(err) {
+                    expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                    expect(err.response).to.be.json;
+                    requiredFields.verifyErrorResponse(err.response.body);
+                });
         });
     });
 });

--- a/test/categories/getCategoriesIT.js
+++ b/test/categories/getCategoriesIT.js
@@ -41,7 +41,7 @@ describe('magento getCategories', function() {
         before(function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'tree'
                 })
@@ -55,7 +55,7 @@ describe('magento getCategories', function() {
         it('returns all categories in tree structure', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'tree'
                 })
@@ -80,7 +80,7 @@ describe('magento getCategories', function() {
         it('returns all categories in flat structure', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'flat'
                 })
@@ -103,7 +103,7 @@ describe('magento getCategories', function() {
             const categoryId = MEN_CATEGORY_ID;
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     id: categoryId
                 })
@@ -124,7 +124,7 @@ describe('magento getCategories', function() {
         it('returns all categories in a tree structure with only root nodes', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'tree',
                     depth: '0'
@@ -148,7 +148,7 @@ describe('magento getCategories', function() {
         it.skip('returns all categories in tree structure sorted by their names', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'tree',
                     sort: 'name.desc'
@@ -171,7 +171,7 @@ describe('magento getCategories', function() {
         it.skip('returns all categories in tree structure with subcategories sorted by their names', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'tree',
                     sort: 'name.desc'
@@ -194,7 +194,7 @@ describe('magento getCategories', function() {
         it.skip('returns all categories in flat structure sorted by their names', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'flat',
                     sort: 'name.desc'
@@ -217,7 +217,7 @@ describe('magento getCategories', function() {
         it.skip('returns a subset of categories in tree structure as defined by paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'tree',
                     limit: 5,
@@ -241,7 +241,7 @@ describe('magento getCategories', function() {
         it.skip('returns a subset of categories in flat structure as defined by paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'flat',
                     limit: 7,
@@ -264,7 +264,7 @@ describe('magento getCategories', function() {
         it('returns a 400 error for invalid paging parameters', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(`${env.categoriesPackage}getCategories`)
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({ limit: -7 })
                 .then(function() {
                     chai.assert.fail();
@@ -279,7 +279,7 @@ describe('magento getCategories', function() {
         it('returns a 404 error for a non existent category', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(`${env.categoriesPackage}getCategories`)
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({ id: '999999999999999' })
                 .then(function() {
                     chai.assert.fail();

--- a/test/categories/getCategoriesIT.js
+++ b/test/categories/getCategoriesIT.js
@@ -41,6 +41,7 @@ describe('magento getCategories', function() {
         before(function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'tree'
                 })
@@ -54,6 +55,7 @@ describe('magento getCategories', function() {
         it('returns all categories in tree structure', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'tree'
                 })
@@ -78,6 +80,7 @@ describe('magento getCategories', function() {
         it('returns all categories in flat structure', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'flat'
                 })
@@ -100,6 +103,7 @@ describe('magento getCategories', function() {
             const categoryId = MEN_CATEGORY_ID;
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     id: categoryId
                 })
@@ -120,6 +124,7 @@ describe('magento getCategories', function() {
         it('returns all categories in a tree structure with only root nodes', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'tree',
                     depth: '0'
@@ -143,6 +148,7 @@ describe('magento getCategories', function() {
         it.skip('returns all categories in tree structure sorted by their names', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'tree',
                     sort: 'name.desc'
@@ -165,6 +171,7 @@ describe('magento getCategories', function() {
         it.skip('returns all categories in tree structure with subcategories sorted by their names', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'tree',
                     sort: 'name.desc'
@@ -187,6 +194,7 @@ describe('magento getCategories', function() {
         it.skip('returns all categories in flat structure sorted by their names', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'flat',
                     sort: 'name.desc'
@@ -209,6 +217,7 @@ describe('magento getCategories', function() {
         it.skip('returns a subset of categories in tree structure as defined by paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'tree',
                     limit: 5,
@@ -232,6 +241,7 @@ describe('magento getCategories', function() {
         it.skip('returns a subset of categories in flat structure as defined by paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'flat',
                     limit: 7,
@@ -254,6 +264,7 @@ describe('magento getCategories', function() {
         it('returns a 400 error for invalid paging parameters', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(`${env.categoriesPackage}getCategories`)
+                .set({'Cache-Control': 'no-cache'})
                 .query({ limit: -7 })
                 .then(function() {
                     chai.assert.fail();
@@ -268,6 +279,7 @@ describe('magento getCategories', function() {
         it('returns a 404 error for a non existent category', function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(`${env.categoriesPackage}getCategories`)
+                .set({'Cache-Control': 'no-cache'})
                 .query({ id: '999999999999999' })
                 .then(function() {
                     chai.assert.fail();

--- a/test/lib/addressITHelper.js
+++ b/test/lib/addressITHelper.js
@@ -259,7 +259,7 @@ module.exports.tests = function (ctx, addressType) {
                 expect(billingAddress.firstName).to.be.undefined;
                 expect(billingAddress.region).to.be.undefined;
                 expect(billingAddress.phone).to.be.undefined;
-            });;
+            });
     };
     
     return that;

--- a/test/lib/requiredFields.js
+++ b/test/lib/requiredFields.js
@@ -17,24 +17,223 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-module.exports = {
-    verifyErrorResponse: function(err) {
-        expect(err).to.have.own.property("type");
-        expect(err).to.have.own.property("reason");
-        expect(err).to.have.own.property("message");
-    },
-    verifyProduct: function(p) {
-        expect(p).to.have.own.property("id");
-        expect(p).to.have.own.property("name");
-        expect(p).to.have.own.property("prices");
-        expect(p).to.have.own.property("masterVariantId");
-        expect(p).to.have.own.property("variants");
-    },
-    verifyProductVariant: function(p) {
-        expect(p).to.have.own.property("id");
-        expect(p).to.have.own.property("name");
-        expect(p).to.have.own.property("prices");
-        expect(p).to.have.own.property("sku");
-        expect(p).to.have.own.property("available");
+/**
+ * RequiredFields checks the existence of required fields as defined in the API specification.
+ */
+class RequiredFields {
+
+    verifyErrorResponse(o) {
+        expect(o).to.have.own.property("type");
+        expect(o).to.have.own.property("reason");
+        expect(o).to.have.own.property("message");
     }
-};
+
+    verifyProduct(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("prices");
+        expect(o).to.have.own.property("masterVariantId");
+        expect(o).to.have.own.property("variants");
+        if (!rec) return;
+
+        for (let price of o.prices) {
+            this.verifyPrice(price);
+        }
+        for (let variant of o.variants) {
+            this.verifyProductVariant(variant);
+        }
+    }
+
+    verifyProductVariant(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("prices");
+        expect(o).to.have.own.property("sku");
+        expect(o).to.have.own.property("available");
+        if (!rec) return;
+        for (let price of o.prices) {
+            this.verifyPrice(price);
+        }
+    }
+
+    verifyFacet(o, rec = true) {
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("label");
+        expect(o).to.have.own.property("type");
+        expect(o).to.have.own.property("facetValues");
+        if (!rec) return;
+        for (let facetValue of o.facetValues) {
+            this.verifyFacetValue(facetValue);
+        }
+    }
+
+    verifyFacetValue(o) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("value");
+    }
+
+    verifyCustomer(o) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("email");
+        expect(o).to.have.own.property("firstname");
+        expect(o).to.have.own.property("lastname");
+    }
+
+    verifyLoginResult(o, rec = true) {
+        expect(o).to.have.own.property("customer");
+        if (!rec) return;
+        this.verifyCustomer(o.customer);
+    }
+
+    verifyDiscount(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("type");
+        expect(o).to.have.own.property("discountedAmount");
+        if (!rec) return;
+        this.verifyPrice(o.discountedAmount);
+    }
+
+    verifyInventoryItem(o) {
+        expect(o).to.have.own.property("inventoryId");
+        expect(o).to.have.own.property("productId");
+        expect(o).to.have.own.property("availableQuantity");
+    }
+
+    verifyShoppingList(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("entries");
+        if (!rec) return;
+        for (let entry of o.entries) {
+            this.verifyShoppingListEntry(entry);
+        }
+    }
+
+    verifyShoppingListEntry(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("productVariant");
+        expect(o).to.have.own.property("quantity");
+        if (!rec) return;
+        for (let variant of o.productVariant) {
+            this.verifyProductVariant(variant);
+        }
+    }
+
+    verifyAddressWrapper(o, rec = true) {
+        expect(o).to.have.own.property("address");
+        if (!rec) return;
+        this.verifyAddress(o.address);
+    }
+
+    verifyPaymentWrapper(o, rec = true) {
+        expect(o).to.have.own.property("payment");
+        if (!rec) return;
+        this.verifyPayment(o.payment);
+    }
+
+    verifyAddress(o) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("firstName");
+        expect(o).to.have.own.property("lastName");
+        expect(o).to.have.own.property("country");
+        expect(o).to.have.own.property("city");
+        expect(o).to.have.own.property("postalCode");
+        expect(o).to.have.own.property("streetName");
+    }
+
+    verifyAsset(o) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("url");
+    }
+
+    verifyAttribute(o) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("value");
+    }
+
+    verifyPagedResponse(o) {
+        expect(o).to.have.own.property("offset");
+        expect(o).to.have.own.property("count");
+        expect(o).to.have.own.property("total");
+        expect(o).to.have.own.property("results");
+    }
+
+    verifyPayment(o) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("method");
+    }
+
+    verifyPrice(o) {
+        expect(o).to.have.own.property("currency");
+        expect(o).to.have.own.property("centAmount");
+    }
+
+    verifyTaxInfo(o) {
+        expect(o).to.have.own.property("totalCentAmount");
+    }
+
+    verifyTaxPortion(o) {
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("centAmount");
+    }
+
+    verifyCategory(o) {
+        expect(o).to.have.own.property("id");
+    }
+
+    verifyCart(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("cartEntries");
+        expect(o).to.have.own.property("totalProductPrice");
+        expect(o).to.have.own.property("currency");
+        if (!rec) return;
+        this.verifyPrice(o.totalProductPrice);
+        for (let entry of o.cartEntries) {
+            this.verifyCartEntry(entry);
+        }
+    }
+
+    verifyCartEntry(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("quantity");
+        expect(o).to.have.own.property("productVariant");
+        expect(o).to.have.own.property("unitPrice");
+        expect(o).to.have.own.property("cartEntryPrice");
+        expect(o).to.have.own.property("type");
+        if (!rec) return;
+        this.verifyPrice(o.unitPrice);
+        this.verifyPrice(o.cartEntryPrice);
+        this.verifyProductVariant(o.productVariant);
+    }
+
+    verifyCoupon(o) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("code");
+    }
+
+    verifyOrder(o) {
+        expect(o).to.have.own.property("id");
+    }
+
+    verifyShippingInfo(o, rec = true) {
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("price");
+        expect(o).to.have.own.property("shippingTaxInfo");
+        expect(o).to.have.own.property("id");
+        if (!rec) return;
+        this.verifyPrice(o.price);
+        this.verifyTaxInfo(o.shippingTaxInfo);
+    }
+
+    verifyShippingMethod(o, rec = true) {
+        expect(o).to.have.own.property("id");
+        expect(o).to.have.own.property("name");
+        expect(o).to.have.own.property("price");
+        if (!rec) return;
+        this.verifyPrice(o.price);
+    }
+
+}
+
+module.exports = new RequiredFields();

--- a/test/lib/requiredFields.js
+++ b/test/lib/requiredFields.js
@@ -14,18 +14,27 @@
 
 'use strict';
 
-const fs = require('fs');
+const chai = require('chai');
+const expect = chai.expect;
 
 module.exports = {
-    getPathForAction: function (testDirName, action) {
-        return testDirName.replace('/test/', '/src/').concat('/').concat(action);
+    verifyErrorResponse: function(err) {
+        expect(err).to.have.own.property("type");
+        expect(err).to.have.own.property("reason");
+        expect(err).to.have.own.property("message");
     },
-
-    parseJsonFile: function(path) {
-        return JSON.parse(fs.readFileSync(path, 'utf8'))
+    verifyProduct: function(p) {
+        expect(p).to.have.own.property("id");
+        expect(p).to.have.own.property("name");
+        expect(p).to.have.own.property("prices");
+        expect(p).to.have.own.property("masterVariantId");
+        expect(p).to.have.own.property("variants");
     },
-
-    clone: function(object) {
-        return JSON.parse(JSON.stringify(object));
+    verifyProductVariant: function(p) {
+        expect(p).to.have.own.property("id");
+        expect(p).to.have.own.property("name");
+        expect(p).to.have.own.property("prices");
+        expect(p).to.have.own.property("sku");
+        expect(p).to.have.own.property("available");
     }
 };

--- a/test/orders/postOrderIT.js
+++ b/test/orders/postOrderIT.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
+const requiredFields = require('../lib/requiredFields');
 
 const expect = chai.expect;
 
@@ -95,6 +96,8 @@ describe('Magento postOrder', function () {
                        .query({})
                        .catch(function (err) {
                            expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                           expect(err.response).to.be.json;
+                           requiredFields.verifyErrorResponse(err.response.body);
                        });
         });
 
@@ -104,6 +107,8 @@ describe('Magento postOrder', function () {
                        .query({cartId: 'non-existing-cart-id-1'})
                        .catch(function (err) {
                            expect(err.response).to.have.status(HttpStatus.NOT_FOUND);
+                           expect(err.response).to.be.json;
+                           requiredFields.verifyErrorResponse(err.response.body);
                        });
         });
 
@@ -113,6 +118,8 @@ describe('Magento postOrder', function () {
                        .query({cartId: cartId})
                        .catch(function (err) {
                            expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                           expect(err.response).to.be.json;
+                           requiredFields.verifyErrorResponse(err.response.body);
                        });
         });
 
@@ -161,8 +168,7 @@ describe('Magento postOrder', function () {
                             expect(res).to.have.status(HttpStatus.CREATED);
                             expect(res).to.have.property('headers');
                             expect(res.headers).to.have.property('location');
-                            // Verify order
-                            expect(res.body).to.have.property('id');
+                            requiredFields.verifyOrder(res.body);
                         });
         });
 

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -3,9 +3,9 @@
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@adobe/commerce-cif-common": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.15.tgz",
-			"integrity": "sha512-tRzdh7jdeZuIZ2rlrWjy+3+PVxXD+d5D41Z8q9yVhu6IKRm2GqNsDqOVnvEIPlzalXmdsy7wphDSxV6cbR28kQ==",
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/@adobe/commerce-cif-common/-/commerce-cif-common-0.1.17.tgz",
+			"integrity": "sha512-TBHa7JRupiypXzoc5JILZLnQIoQhfdE0mV/cmb1kTb4UElT/41GC2yVZF5LQ5NQOUwOfMGtZ+8ckQClnOjdvYQ==",
 			"requires": {
 				"http-status-codes": "1.1.6"
 			}

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/adobe/commerce-cif-magento.git"
   },
   "dependencies": {
-    "@adobe/commerce-cif-common": "0.1.15",
+    "@adobe/commerce-cif-common": "0.1.17",
     "@adobe/commerce-cif-model": "0.1.123",
     "request": "2.87.0",
     "request-promise-native": "1.0.5",

--- a/test/products/searchProductsIT.js
+++ b/test/products/searchProductsIT.js
@@ -43,6 +43,7 @@ describe('magento searchProducts', function() {
         before(function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     type: 'tree'
                 })
@@ -61,6 +62,7 @@ describe('magento searchProducts', function() {
         it('returns a 500 error if parameters are missing', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
                     expect(err.response).to.be.json;
@@ -71,6 +73,7 @@ describe('magento searchProducts', function() {
         it('returns products in a category', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     filter: `categories.id:"${WOMENSHORTS_CATEGORY_ID}"`
                 })
@@ -94,6 +97,7 @@ describe('magento searchProducts', function() {
         it.skip('returns products in a category and all its subcategories', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     filter: `categories.id:subtree("${MEN_CATEGORY_ID}")`
                 })
@@ -117,6 +121,7 @@ describe('magento searchProducts', function() {
             const sku = 'meskwielt';
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     filter: `variants.sku:"${sku}"`
                 })
@@ -152,6 +157,7 @@ describe('magento searchProducts', function() {
             const searchTerm = 'jacket';
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     text: searchTerm
                 })
@@ -174,6 +180,7 @@ describe('magento searchProducts', function() {
         it('returns products sorted by their name', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     filter: `categories.id:"${WOMENSHORTS_CATEGORY_ID}"`,
                     sort: 'name.desc',
@@ -202,6 +209,7 @@ describe('magento searchProducts', function() {
         it.skip('returns a 500 error for invalid sorting parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     filter: `categories.id:"${WOMENSHORTS_CATEGORY_ID}"`,
                     sort: 'abc.asc'
@@ -217,6 +225,7 @@ describe('magento searchProducts', function() {
         it.skip('returns a subset of products as defined by paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     filter: `categories.id:subtree("${MEN_CATEGORY_ID}")`,
                     limit: 4,
@@ -243,6 +252,7 @@ describe('magento searchProducts', function() {
         it.skip('returns a 500 error for invalid paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
+                .set({'Cache-Control': 'no-cache'})
                 .query({
                     filter: `categories.id:subtree:"${MEN_CATEGORY_ID}"`,
                     limit: -1

--- a/test/products/searchProductsIT.js
+++ b/test/products/searchProductsIT.js
@@ -43,7 +43,7 @@ describe('magento searchProducts', function() {
         before(function () {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     type: 'tree'
                 })
@@ -62,7 +62,7 @@ describe('magento searchProducts', function() {
         it('returns a 500 error if parameters are missing', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
                     expect(err.response).to.be.json;
@@ -73,7 +73,7 @@ describe('magento searchProducts', function() {
         it('returns products in a category', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     filter: `categories.id:"${WOMENSHORTS_CATEGORY_ID}"`
                 })
@@ -97,7 +97,7 @@ describe('magento searchProducts', function() {
         it.skip('returns products in a category and all its subcategories', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     filter: `categories.id:subtree("${MEN_CATEGORY_ID}")`
                 })
@@ -121,7 +121,7 @@ describe('magento searchProducts', function() {
             const sku = 'meskwielt';
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     filter: `variants.sku:"${sku}"`
                 })
@@ -157,7 +157,7 @@ describe('magento searchProducts', function() {
             const searchTerm = 'jacket';
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     text: searchTerm
                 })
@@ -180,7 +180,7 @@ describe('magento searchProducts', function() {
         it('returns products sorted by their name', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     filter: `categories.id:"${WOMENSHORTS_CATEGORY_ID}"`,
                     sort: 'name.desc',
@@ -209,7 +209,7 @@ describe('magento searchProducts', function() {
         it.skip('returns a 500 error for invalid sorting parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     filter: `categories.id:"${WOMENSHORTS_CATEGORY_ID}"`,
                     sort: 'abc.asc'
@@ -225,7 +225,7 @@ describe('magento searchProducts', function() {
         it.skip('returns a subset of products as defined by paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     filter: `categories.id:subtree("${MEN_CATEGORY_ID}")`,
                     limit: 4,
@@ -252,7 +252,7 @@ describe('magento searchProducts', function() {
         it.skip('returns a 500 error for invalid paging parameters', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'searchProducts')
-                .set({'Cache-Control': 'no-cache'})
+                .set('Cache-Control', 'no-cache')
                 .query({
                     filter: `categories.id:subtree:"${MEN_CATEGORY_ID}"`,
                     limit: -1

--- a/test/products/searchProductsIT.js
+++ b/test/products/searchProductsIT.js
@@ -77,14 +77,11 @@ describe('magento searchProducts', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(4);
                     expect(res.body.results).to.have.lengthOf(4);
                     for (let result of res.body.results) {
                         requiredFields.verifyProduct(result);
-                        for (let variant of result.variants) {
-                            requiredFields.verifyProductVariant(variant);
-                        }
-
                         expect(result.categories).to.deep.include({"id": WOMENSHORTS_CATEGORY_ID});
                     }
                 })
@@ -103,14 +100,12 @@ describe('magento searchProducts', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(25);
                     expect(res.body.results).to.have.lengthOf(25);
                     for(let result of res.body.results) {
                         expect(result.categories).to.have.lengthOf.at.least(1);
                         requiredFields.verifyProduct(result);
-                        for (let variant of result.variants) {
-                            requiredFields.verifyProductVariant(variant);
-                        }
                     }
                 })
                 .catch(function(err) {
@@ -128,6 +123,7 @@ describe('magento searchProducts', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(1);
 
                     // Verify structure
@@ -139,9 +135,6 @@ describe('magento searchProducts', function() {
                     expect(product).to.have.own.property('createdDate');
 
                     expect(product.variants).to.have.lengthOf(15);
-                    for (let variant of product.variants) {
-                        requiredFields.verifyProductVariant(variant);
-                    }
                     expect(product.attributes).to.have.lengthOf(2);
                     expect(product.attributes.find(o => {return o.id === 'summary'})).to.be.an('object');
                     expect(product.attributes.find(o => {return o.id === 'features'})).to.be.an('object');
@@ -165,14 +158,12 @@ describe('magento searchProducts', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(5);
                     expect(res.body.results).to.have.lengthOf(5);
                     expect(res.text.split(searchTerm)).to.have.lengthOf.at.least(5);
                     for(let result of res.body.results) {
                         requiredFields.verifyProduct(result);
-                        for (let variant of result.variants) {
-                            requiredFields.verifyProductVariant(variant);
-                        }
                     }
                 })
                 .catch(function(err) {
@@ -191,13 +182,11 @@ describe('magento searchProducts', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.count).to.equal(4);
                     expect(res.body.results).to.have.lengthOf(4);
                     for(let result of res.body.results) {
                         requiredFields.verifyProduct(result);
-                        for (let variant of result.variants) {
-                            requiredFields.verifyProductVariant(variant);
-                        }
                     }
 
                     // Verfiy sorting
@@ -219,6 +208,7 @@ describe('magento searchProducts', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
                     requiredFields.verifyErrorResponse(err.response.body);
                 });
         });
@@ -235,15 +225,13 @@ describe('magento searchProducts', function() {
                 .then(function (res) {
                     expect(res).to.be.json;
                     expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
                     expect(res.body.offset).to.equal(20);
                     expect(res.body.count).to.equal(4);
                     expect(res.body.total).to.equal(100);
                     expect(res.body.results).to.have.lengthOf(4);
                     for(let result of res.body.results) {
                         requiredFields.verifyProduct(result);
-                        for (let variant of result.variants) {
-                            requiredFields.verifyProductVariant(variant);
-                        }
                     }
                 })
                 .catch(function(err) {
@@ -261,6 +249,7 @@ describe('magento searchProducts', function() {
                 })
                 .catch(function(err) {
                     expect(err.response).to.have.status(HttpStatus.BAD_REQUEST);
+                    expect(err.response).to.be.json;
                     requiredFields.verifyErrorResponse(err.response.body);
                 });
         });


### PR DESCRIPTION
* Updated ITs to check for required fields in responses according to https://github.com/adobe/commerce-cif-api/pull/16
* Updated implementation to return required fields
* Updated @adobe/commerce-cif-common dependency, so that `ErrorResponses` also return all required fields
* Minor fix to include test results in CircleCI