### PR TITLE
CIF-334 - Setup Continuous Delivery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,14 @@ jobs:
       - run:
           name: Release
           command: node ci/release.js
+  deploy:
+    docker:
+      - image: adobe/commerce-cif-ci-env:v0.0.1
+    steps:
+      - checkout
+      - run:
+          name: Deploy
+          command: node ci/deploy.js
 
 workflows:
   version: 2
@@ -36,4 +44,10 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^@(.+)@release-(major|minor|patch)$/ 
+              only: /^@(.+)@release-(major|minor|patch)$/
+      - deploy:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^@adobe\/(.*)-[\d]+.[\d]+.[\d]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
 
 workflows:
   version: 2
-  build-and-release:
+  continuous-delivery:
     jobs:
       - build:
           filters:
@@ -46,6 +46,8 @@ workflows:
             tags:
               only: /^@(.+)@release-(major|minor|patch)$/
       - deploy:
+          requires:
+            - build
           filters:
             branches:
               ignore: /.*/

--- a/ci/ci.js
+++ b/ci/ci.js
@@ -149,8 +149,16 @@ module.exports = class CI {
      * Determine the module to be released from a release tag and a given object
      * with module to path mappings.
      */
-    parseReleaseModule(tag, mappings) {
+    parseModuleFromReleaseTag(tag, mappings) {
         return Object.keys(mappings).find(key => tag.startsWith(`@${key}@`));
     };
+
+    /**
+     * Determine the module that was released from a given release version tag
+     * and a given object with module to path mappings.
+     */
+    parseModuleFromVersionTag(tag, mappings) {
+        return Object.keys(mappings).find(key => tag.startsWith(`@adobe/${key}-`));
+    }
 
 };

--- a/ci/deploy.js
+++ b/ci/deploy.js
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ *
+ *    Copyright 2018 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+'use strict';
+
+const CI = require('./ci.js');
+const ci = new CI();
+
+// Modules in this repository
+const releaseableModules = {
+    'commerce-cif-magento-cart': 'src/carts',
+    'commerce-cif-magento-category': 'src/categories',
+    'commerce-cif-magento-common': 'src/common',
+    'commerce-cif-magento-customer': 'src/customer',
+    'commerce-cif-magento-order': 'src/orders',
+    'commerce-cif-magento-product': 'src/products'
+}
+
+ci.context();
+
+// Check for tag
+let gitTag = process.env.CIRCLE_TAG;
+if (!gitTag) {
+    return;
+}
+
+// Find module of that release
+let moduleToRelease = ci.parseModuleFromVersionTag(gitTag, releaseableModules);
+if (!moduleToRelease) {
+    throw new Error('Invalid version tag.');
+}
+
+ci.stage('DEPLOYMENT PROVISION');
+
+// Check out released version
+ci.sh(`git checkout '${gitTag}' `);
+
+// Provision
+ci.sh('npm install');
+
+ci.stage(`PERFORM DEPLOYMENT OF ${moduleToRelease}`);
+
+ci.dir(releaseableModules[moduleToRelease], () => {
+    ci.withWskCredentials(process.env.WSK_API_HOST, process.env.PROD_WSK_NAMESPACE, process.env.PROD_WSK_AUTH_STRING, () => {
+        ci.sh('npm run deploy-package');
+    });
+});
+
+ci.stage('DEPLOYMENT DONE');

--- a/ci/deploy.js
+++ b/ci/deploy.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const CI = require('./ci.js');
 const ci = new CI();
 

--- a/ci/deploy.js
+++ b/ci/deploy.js
@@ -17,17 +17,10 @@
 const CI = require('./ci.js');
 const ci = new CI();
 
-// Modules in this repository
-const releaseableModules = {
-    'commerce-cif-magento-cart': 'src/carts',
-    'commerce-cif-magento-category': 'src/categories',
-    'commerce-cif-magento-common': 'src/common',
-    'commerce-cif-magento-customer': 'src/customer',
-    'commerce-cif-magento-order': 'src/orders',
-    'commerce-cif-magento-product': 'src/products'
-}
-
 ci.context();
+
+// Modules in this repository
+const modules = JSON.parse(fs.readFileSync('ci/modules.json'));
 
 // Check for tag
 let gitTag = process.env.CIRCLE_TAG;
@@ -36,7 +29,7 @@ if (!gitTag) {
 }
 
 // Find module of that release
-let moduleToRelease = ci.parseModuleFromVersionTag(gitTag, releaseableModules);
+let moduleToRelease = ci.parseModuleFromVersionTag(gitTag, modules);
 if (!moduleToRelease) {
     throw new Error('Invalid version tag.');
 }
@@ -51,7 +44,7 @@ ci.sh('npm install');
 
 ci.stage(`PERFORM DEPLOYMENT OF ${moduleToRelease}`);
 
-ci.dir(releaseableModules[moduleToRelease], () => {
+ci.dir(modules[moduleToRelease], () => {
     ci.withWskCredentials(process.env.WSK_API_HOST, process.env.PROD_WSK_NAMESPACE, process.env.PROD_WSK_AUTH_STRING, () => {
         ci.sh('npm run deploy-package');
     });

--- a/ci/modules.json
+++ b/ci/modules.json
@@ -1,0 +1,8 @@
+{
+    "commerce-cif-magento-cart": "src/carts",
+    "commerce-cif-magento-category": "src/categories",
+    "commerce-cif-magento-common": "src/common",
+    "commerce-cif-magento-customer": "src/customer",
+    "commerce-cif-magento-order": "src/orders",
+    "commerce-cif-magento-product": "src/products"
+}

--- a/ci/release.js
+++ b/ci/release.js
@@ -15,20 +15,14 @@
 'use strict';
 
 const cp = require('child_process');
+const fs = require('fs');
 const CI = require('./ci.js');
 const ci = new CI();
 
-// Modules in this repository
-const releaseableModules = {
-    'commerce-cif-magento-cart': 'src/carts',
-    'commerce-cif-magento-category': 'src/categories',
-    'commerce-cif-magento-common': 'src/common',
-    'commerce-cif-magento-customer': 'src/customer',
-    'commerce-cif-magento-order': 'src/orders',
-    'commerce-cif-magento-product': 'src/products'
-}
-
 ci.context();
+
+// Modules in this repository
+const releaseableModules = JSON.parse(fs.readFileSync('ci/modules.json'));
 
 // Check for tag
 let gitTag = process.env.CIRCLE_TAG;

--- a/ci/release.js
+++ b/ci/release.js
@@ -37,7 +37,7 @@ if (!gitTag) {
 }
 
 // Find module that should be release
-let moduleToRelease = ci.parseReleaseModule(gitTag, releaseableModules);
+let moduleToRelease = ci.parseModuleFromReleaseTag(gitTag, releaseableModules);
 if (!moduleToRelease) {
     throw new Error('Invalid release tag.');
 }
@@ -74,7 +74,8 @@ try {
             ci.sh(`git commit -m "@releng Release: @adobe/${moduleToRelease}-${newVersion}"`);
 
             // Add tag
-            ci.sh(`git tag -a @adobe/${moduleToRelease}-${newVersion} -m "@adobe/${moduleToRelease}-${newVersion}"`);
+            let versionTag = `@adobe/${moduleToRelease}-${newVersion}`;
+            ci.sh(`git tag -a ${versionTag} -m "${versionTag}"`);
 
             // Publish to npm
             ci.sh('npm publish --access public');


### PR DESCRIPTION
* I added a new `deploy` job which is triggered by the version tag which gets added by the release job.
* The deployment job explicitly checks out the version tag and deploys this version (both under the current and latest version tag).
* The deployment job only deploys the released node package, not the whole connector (e.g. only cart actions).
* The deployment is done to the `ccif-core-library` namespace.