### PR TITLE
CIF-421 - Magento searchProducts action does not support multiple parameters

### DIFF
--- a/src/products/ProductGraphQlRequestBuilder.js
+++ b/src/products/ProductGraphQlRequestBuilder.js
@@ -82,7 +82,7 @@ class ProductGraphQlRequestBuilder {
                     if (parts.length > 1) {
                         values = parts;
                     } else {
-                        value = matches[1];
+                        value = parts[0];
                     }
                 }
             }

--- a/src/products/ProductGraphQlRequestBuilder.js
+++ b/src/products/ProductGraphQlRequestBuilder.js
@@ -72,17 +72,27 @@ class ProductGraphQlRequestBuilder {
 
             // Parse value
             let value;
+            let values;
             let split = filterArg.split(':');
             if (split.length == 2) {
                 let val = split[1];
-                let matches = val.match(/.*?"(.*?)".*/);
+                let matches = val.match(/.*?"(.*)".*/);
                 if (matches) {
-                    value = matches[1];
+                    let parts = matches[1].replace(/"/g, "").split(',');
+                    if (parts.length > 1) {
+                        values = parts;
+                    } else {
+                        value = matches[1];
+                    }
                 }
             }
 
-            if (field && value) {
-                filterFields.push({field: field, value: value});
+            if (field) {
+                if (value) {
+                    filterFields.push({field: field, value: value});
+                } else if (values) {
+                    filterFields.push({field: field, values: values});
+                } 
             }
         });
 

--- a/src/products/searchProducts.graphql
+++ b/src/products/searchProducts.graphql
@@ -3,7 +3,12 @@
         filter: {
             {{#each filter}}
             {{field}}: {
+                {{#if value}}
                 eq: "{{value}}"
+                {{/if}}
+                {{#if values}}
+                in: [{{#each values}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}]
+                {{/if}}
             }
             {{/each}}
         }

--- a/test/carts/getShippingMethodsTest.js
+++ b/test/carts/getShippingMethodsTest.js
@@ -66,7 +66,6 @@ describe('Magento getShippingMethods for a cart', () => {
 
         specsBuilder().forEach(spec => {
             it('successfully returns 400 when cart has no shipping address', () => {
-                console.log(spec);
                 let postRequestWithBody = requestConfig(encodeURI(`http://${config.MAGENTO_HOST}/rest/V1/${spec.baseEndpoint}/estimate-shipping-methods`),
                     'POST', spec.token);
                 postRequestWithBody.body = {

--- a/test/carts/postCartEntryTest.js
+++ b/test/carts/postCartEntryTest.js
@@ -168,7 +168,6 @@ describe('Magento postCartEntry', () => {
 
                 return this.prepareResolveMultipleResponse(mockedResponses, expectedArgs).execute(Object.assign(spec.args, config))
                     .then(result => {
-                        console.log(JSON.stringify(result, null, 2));
                         assert.isDefined(result.response);
                         assert.strictEqual(result.response.statusCode, 201);
                         assert.isDefined(result.response.headers);

--- a/test/products/ProductGraphQlRequestBuilderTest.js
+++ b/test/products/ProductGraphQlRequestBuilderTest.js
@@ -179,6 +179,22 @@ describe('Magento ProductGraphQlRequestBuilder', () => {
             });
         });
 
+        it('parses a filter parameter with multiple values', () => {
+            let b = new ProductGraphQlRequestBuilder('', '', {
+                filter: 'variants.sku:"abc","def"'
+            });
+            b._parseFilter();
+
+            assert.deepEqual(b.context, {
+                filter: [
+                    {
+                        field: 'sku',
+                        values: ['abc', 'def']
+                    }
+                ]
+            });
+        });
+
         it('rejects invalid filter parameters', () => {
             let b = new ProductGraphQlRequestBuilder('', '', {
                 filter: 'categories.subtree:14|bad.filter.sku:"abc|categories.id:14'

--- a/test/products/searchProductsIT.js
+++ b/test/products/searchProductsIT.js
@@ -163,6 +163,23 @@ describe('magento searchProducts', function() {
                 });
         });
 
+        it('returns a valid response with a filter parameter and search string', function() {
+            return chai.request(env.openwhiskEndpoint)
+                .get(env.productsPackage + 'searchProducts')
+                .set('Cache-Control', 'no-cache')
+                .query({
+                    filter: 'categories.id:"11"', // category alone has 6 matches
+                    text: 'gloves' // search has 4 matches
+                })
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
+                    // Combined request has a single match
+                    expect(res.body.count).to.equal(1);
+                });
+        });
+
         it('returns products matching a search string', function() {
             const searchTerm = 'jacket';
             return chai.request(env.openwhiskEndpoint)

--- a/test/products/searchProductsIT.js
+++ b/test/products/searchProductsIT.js
@@ -144,6 +144,25 @@ describe('magento searchProducts', function() {
                 });
         });
 
+        it('returns a valid response with 2 SKUs', function() {
+            const sku1 = 'meskwielt';
+            const sku2 = 'mesusupis';
+            return chai.request(env.openwhiskEndpoint)
+                .get(env.productsPackage + 'searchProducts')
+                .set('Cache-Control', 'no-cache')
+                .query({
+                    filter: `variants.sku:"${sku1}","${sku2}"`
+                })
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+                    requiredFields.verifyPagedResponse(res.body);
+                    expect(res.body.count).to.equal(2);
+                    expect(res.body.results.find(p => p.sku === sku1)).to.not.be.null;
+                    expect(res.body.results.find(p => p.sku === sku2)).to.not.be.null;
+                });
+        });
+
         it('returns products matching a search string', function() {
             const searchTerm = 'jacket';
             return chai.request(env.openwhiskEndpoint)


### PR DESCRIPTION
- added support for multiple search parameter values for a given filter

Adds support for multiple values for search parameters.

## Description

Adds support for multiple values for search parameters.

## Related Issue

CIF-421

## Motivation and Context

See CIF-421

## How Has This Been Tested?

Added unit + integration test.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
