### PR TITLE
CIF-284 - fix categories 401 permission issue

### DIFF
--- a/src/categories/MagentoCategories.js
+++ b/src/categories/MagentoCategories.js
@@ -22,6 +22,9 @@ class MagentoCategories extends MagentoClientBase {
     constructor(args, categoriesMapper, endpoint) {
         super(args, categoriesMapper, endpoint, ERROR_TYPE);
         this.currentSortIndex = 0;
+        //undefine the customer token to make sure we are not using for categories requests.
+        //this might be a bug on this endpoint
+        this.customerToken = undefined;
     }
     
     getCategories(type, depth) {

--- a/src/categories/MagentoCategories.js
+++ b/src/categories/MagentoCategories.js
@@ -22,8 +22,8 @@ class MagentoCategories extends MagentoClientBase {
     constructor(args, categoriesMapper, endpoint) {
         super(args, categoriesMapper, endpoint, ERROR_TYPE);
         this.currentSortIndex = 0;
-        //undefine the customer token to make sure we are not using for categories requests.
-        //this might be a bug on this endpoint
+        //undefine the customer token to make sure we are not using it for categories requests.
+        //this might be a bug on this endpoint.
         this.customerToken = undefined;
     }
     

--- a/test/categories/getCategoriesIT.js
+++ b/test/categories/getCategoriesIT.js
@@ -19,8 +19,10 @@ const HttpStatus = require('http-status-codes');
 const setup = require('../lib/setupIT.js').setup;
 const categoriesConfig = require('../lib/config').categoriesConfig;
 const requiredFields = require('../lib/requiredFields');
-
 const expect = chai.expect;
+const extractToken = require('../lib/setupIT').extractToken;
+const CCS_MAGENTO_CUSTOMER_TOKEN = require('../../src/common/MagentoClientBase').const().CCS_MAGENTO_CUSTOMER_TOKEN;
+
 chai.use(require('chai-sorted'));
 chai.use(require('chai-http'));
 
@@ -35,6 +37,7 @@ describe('magento getCategories', function() {
         this.timeout(env.timeout);
 
         let MEN_CATEGORY_ID = null;
+        let accessToken;
 
         before(function () {
             return chai.request(env.openwhiskEndpoint)
@@ -49,6 +52,26 @@ describe('magento getCategories', function() {
                     MEN_CATEGORY_ID = parseInt(res.body.results.find(o => {
                         return o.name === categoriesConfig.MEN.name
                     }).id);
+                    //doing a customer login to also test that the customer token header
+                    // will not override the integration token
+                    return chai.request(env.openwhiskEndpoint)
+                        .get(env.customersPackage + 'postCustomerLogin')
+                        .set('Cache-Control', 'no-cache')
+                        .query({
+                            email: env.magentoCustomerName,
+                            password: env.magentoCustomerPwd
+                        });
+                })
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+
+                    requiredFields.verifyLoginResult(res.body);
+                    expect(res.body.customer.email).to.equal(env.magentoCustomerName);
+                    expect(res.body.cart).to.not.be.undefined;
+                    //check cookie is set
+                    accessToken = extractToken(res);
+                    expect(accessToken).to.not.be.undefined;
                 });
         });
 
@@ -56,6 +79,7 @@ describe('magento getCategories', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.categoriesPackage + 'getCategories')
                 .set('Cache-Control', 'no-cache')
+                .set('cookie', `${CCS_MAGENTO_CUSTOMER_TOKEN}=${accessToken};`)
                 .query({
                     type: 'tree'
                 })

--- a/test/categories/getCategoriesIT.js
+++ b/test/categories/getCategoriesIT.js
@@ -68,7 +68,6 @@ describe('magento getCategories', function() {
 
                     requiredFields.verifyLoginResult(res.body);
                     expect(res.body.customer.email).to.equal(env.magentoCustomerName);
-                    expect(res.body.cart).to.not.be.undefined;
                     //check cookie is set
                     accessToken = extractToken(res);
                     expect(accessToken).to.not.be.undefined;


### PR DESCRIPTION
 by making sure that integration token is always used

<!--- Provide a general summary of your changes in the Title above -->

## Description

I have changed the categories client to always undefine the customer token so that the integration token is used for categories requests. 

## Related Issue

CIF-284

## Motivation and Context

Fix for the categories 401 exception on a customer session. 

## How Has This Been Tested?

IT's and manual tests (with weretail). 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.