### PR TITLE
CIF-432 - Remove eslint-plugin-header fork

### DIFF
--- a/src/carts/package-lock.json
+++ b/src/carts/package-lock.json
@@ -1711,8 +1711,9 @@
 			}
 		},
 		"eslint-plugin-header": {
-			"version": "git+https://github.com/herzog31/eslint-plugin-header.git#7b0139b41b429f1c40fe46227031f816190f32f2",
-			"from": "git+https://github.com/herzog31/eslint-plugin-header.git"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
+			"integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/src/carts/package.json
+++ b/src/carts/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "eslint-plugin-header": "git+https://github.com/herzog31/eslint-plugin-header.git",
+    "eslint-plugin-header": "2.0",
     "serverless": "1.29.0",
     "serverless-openwhisk": "0.13.0",
     "serverless-webpack": "4.3.0",

--- a/src/categories/package-lock.json
+++ b/src/categories/package-lock.json
@@ -1711,8 +1711,9 @@
 			}
 		},
 		"eslint-plugin-header": {
-			"version": "git+https://github.com/herzog31/eslint-plugin-header.git#7b0139b41b429f1c40fe46227031f816190f32f2",
-			"from": "git+https://github.com/herzog31/eslint-plugin-header.git"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
+			"integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/src/categories/package.json
+++ b/src/categories/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "eslint-plugin-header": "git+https://github.com/herzog31/eslint-plugin-header.git",
+    "eslint-plugin-header": "2.0",
     "js-yaml": "3.9.0",
     "serverless": "1.29.0",
     "serverless-openwhisk": "0.13.0",

--- a/src/common/package-lock.json
+++ b/src/common/package-lock.json
@@ -1762,8 +1762,9 @@
 			}
 		},
 		"eslint-plugin-header": {
-			"version": "git+https://github.com/herzog31/eslint-plugin-header.git#7b0139b41b429f1c40fe46227031f816190f32f2",
-			"from": "git+https://github.com/herzog31/eslint-plugin-header.git"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
+			"integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/src/common/package.json
+++ b/src/common/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "eslint-plugin-header": "git+https://github.com/herzog31/eslint-plugin-header.git",
+    "eslint-plugin-header": "2.0",
     "mkdirp": "0.5.1",
     "serverless": "1.29.0",
     "serverless-openwhisk": "0.13.0",

--- a/src/customer/package-lock.json
+++ b/src/customer/package-lock.json
@@ -1711,8 +1711,9 @@
 			}
 		},
 		"eslint-plugin-header": {
-			"version": "git+https://github.com/herzog31/eslint-plugin-header.git#7b0139b41b429f1c40fe46227031f816190f32f2",
-			"from": "git+https://github.com/herzog31/eslint-plugin-header.git"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
+			"integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/src/customer/package.json
+++ b/src/customer/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "eslint-plugin-header": "git+https://github.com/herzog31/eslint-plugin-header.git",
+    "eslint-plugin-header": "2.0",
     "serverless": "1.29.0",
     "serverless-openwhisk": "0.13.0",
     "serverless-webpack": "4.3.0",

--- a/src/orders/package-lock.json
+++ b/src/orders/package-lock.json
@@ -1711,8 +1711,9 @@
 			}
 		},
 		"eslint-plugin-header": {
-			"version": "git+https://github.com/herzog31/eslint-plugin-header.git#7b0139b41b429f1c40fe46227031f816190f32f2",
-			"from": "git+https://github.com/herzog31/eslint-plugin-header.git"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
+			"integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/src/orders/package.json
+++ b/src/orders/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "eslint-plugin-header": "git+https://github.com/herzog31/eslint-plugin-header.git",
+    "eslint-plugin-header": "2.0",
     "serverless": "1.29.0",
     "serverless-openwhisk": "0.13.0",
     "serverless-webpack": "4.3.0",

--- a/src/products/package-lock.json
+++ b/src/products/package-lock.json
@@ -1891,8 +1891,9 @@
 			}
 		},
 		"eslint-plugin-header": {
-			"version": "git+https://github.com/herzog31/eslint-plugin-header.git#7b0139b41b429f1c40fe46227031f816190f32f2",
-			"from": "git+https://github.com/herzog31/eslint-plugin-header.git"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
+			"integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/src/products/package.json
+++ b/src/products/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "copy-webpack-plugin": "4.5.1",
     "eslint": "3.19.0",
-    "eslint-plugin-header": "git+https://github.com/herzog31/eslint-plugin-header.git",
+    "eslint-plugin-header": "2.0",
     "serverless": "1.29.0",
     "serverless-openwhisk": "0.13.0",
     "serverless-webpack": "4.3.0",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -429,8 +429,9 @@
 			}
 		},
 		"eslint-plugin-header": {
-			"version": "git+https://github.com/herzog31/eslint-plugin-header.git#7b0139b41b429f1c40fe46227031f816190f32f2",
-			"from": "git+https://github.com/herzog31/eslint-plugin-header.git"
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz",
+			"integrity": "sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA=="
 		},
 		"espree": {
 			"version": "3.5.4",

--- a/test/package.json
+++ b/test/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "eslint": "3.19.0",
-    "eslint-plugin-header": "git+https://github.com/herzog31/eslint-plugin-header.git"
+    "eslint-plugin-header": "2.0"
   },
   "eslintConfig": {
     "extends": "../.eslintrc.js"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In https://github.com/adobe/commerce-cif-magento/pull/40 the version of `eslint-plugin-header` was changed to a fork that includes a fix for Windows. Since the fix was merged to master, I remove the fork.

## How Has This Been Tested?

Manual tests in Windows VM.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
