### PR TITLE
CIF-476 - Introduce HTTP Vary header for cached CIF responses

### DIFF
--- a/src/common/serverless.yml
+++ b/src/common/serverless.yml
@@ -26,5 +26,5 @@ resources:
 functions:
   webActionTransformer:
     name: ${self:custom.ow-package}/webActionTransformer
-    handler: "@adobe/commerce-cif-web-action-transformer@1.0.1/index.main"
-    ccif_dependency: "@adobe/commerce-cif-web-action-transformer@1.0.1"
+    handler: "@adobe/commerce-cif-web-action-transformer@1.0.2/index.main"
+    ccif_dependency: "@adobe/commerce-cif-web-action-transformer@1.0.2"

--- a/test/categories/getCategoriesIT.js
+++ b/test/categories/getCategoriesIT.js
@@ -307,5 +307,18 @@ describe('magento getCategories', function() {
                     requiredFields.verifyErrorResponse(res.body);
                 });
         });
+
+        it('returns the Vary header', function() {
+            return chai.request(env.openwhiskEndpoint)
+                .get(env.categoriesPackage + 'getCategories')
+                .set('cookie', `${CCS_MAGENTO_CUSTOMER_TOKEN}=${accessToken};`)
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+                    expect(res).to.haveOwnProperty('header');
+                    expect(res.header).to.haveOwnProperty('vary');
+                    expect(res.header.vary).to.equal('Accept-Language');
+                });
+        });
     });
 });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Use new version of web-action-transformer which adds the Vary header to responses.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CIF-476
<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Adds Vary header to responses to instruct caching mechanism that the response may vary depending on the `Accept-Language` header.

## How Has This Been Tested?
Manually deployed all actions and made sure they use the new `web-action-transformer`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
