### PR TITLE
CIF-212 - [Magento] Inventory info in product model

### DIFF
--- a/src/products/ProductMapper.js
+++ b/src/products/ProductMapper.js
@@ -126,7 +126,7 @@ class ProductMapper {
         } else {
             variants = [
                 new ProductVariant.Builder()
-                    .withAvailable(product.stock_status == "IN_STOCK")
+                    .withAvailable(product.stock_status === "IN_STOCK")
                     .withId(product.sku)
                     .withName(product.name || '')
                     .withPrices(prices)

--- a/src/products/ProductMapper.js
+++ b/src/products/ProductMapper.js
@@ -126,7 +126,7 @@ class ProductMapper {
         } else {
             variants = [
                 new ProductVariant.Builder()
-                    .withAvailable(product.stock_status == "IN_STOCK") // TODO: Get actual value from backend
+                    .withAvailable(product.stock_status == "IN_STOCK")
                     .withId(product.sku)
                     .withName(product.name || '')
                     .withPrices(prices)

--- a/src/products/ProductMapper.js
+++ b/src/products/ProductMapper.js
@@ -126,7 +126,7 @@ class ProductMapper {
         } else {
             variants = [
                 new ProductVariant.Builder()
-                    .withAvailable(true) // TODO: Get actual value from backend
+                    .withAvailable(product.stock_status == "IN_STOCK") // TODO: Get actual value from backend
                     .withId(product.sku)
                     .withName(product.name || '')
                     .withPrices(prices)
@@ -161,8 +161,7 @@ class ProductMapper {
      * @private
      */
     _mapProductVariant(product, variant) {
-        // TODO: Get actual value from backend
-        let available = true;
+        let available = variant.stock_status === "IN_STOCK";
         let prices = [];
         if (variant.price && variant.price.regularPrice) {
             prices = [

--- a/src/products/searchProducts.graphql
+++ b/src/products/searchProducts.graphql
@@ -34,6 +34,7 @@
           id
           sku
           name
+          stock_status
           description
           created_at
           updated_at
@@ -66,6 +67,7 @@
                 id
                 sku
                 name
+                stock_status
                 description
                 created_at
                 updated_at

--- a/test/products/ProductMapperTest.js
+++ b/test/products/ProductMapperTest.js
@@ -17,7 +17,7 @@
 const assert = require('chai').assert;
 const searchProductsBySku = require('../resources/searchProductsBySku');
 const searchProductsWithPaging = require('../resources/searchProductsWithPaging');
-const searchSingleProduct = require('../resources/sample-product-search-single-product').body;
+const searchSingleProductData = require('../resources/sample-product-search-single-product');
 const utils = require('../lib/utils');
 
 describe('Magento ProductMapper', () => {
@@ -38,7 +38,7 @@ describe('Magento ProductMapper', () => {
             // clone original sample data before each test
             simpleData = JSON.parse(JSON.stringify(searchProductsBySku));
             pagedData = JSON.parse(JSON.stringify(searchProductsWithPaging));
-            singleProductData = JSON.parse(JSON.stringify(searchSingleProduct));
+            singleProductData = JSON.parse(JSON.stringify(searchSingleProductData.simpleProductResponse.body));
         });
 
         it('Maps Magento graphQL response into valid CIF Cloud product', () => {

--- a/test/products/getProductIT.js
+++ b/test/products/getProductIT.js
@@ -50,23 +50,6 @@ describe('magento getProduct', function() {
                     expect(res.body.id).to.equal(productId);
                     expect(res.body).to.have.own.property('categories');
                     expect(res.body).to.have.own.property('createdAt');
-                    expect(res.body.variants[0].available).to.equal(true);
-                });
-        });
-
-        // the product with SKU eqbisublp is intentionally marked as OUT_OF_STOCK on Magento
-        it('returns the stock information for an unavailable product', function() {
-            return chai.request(env.openwhiskEndpoint)
-                .get(env.productsPackage + 'getProductById')
-                .query({id: 'eqbisublp'})
-                .set('Cache-Control', 'no-cache')
-                .then(function (res) {
-                    expect(res).to.be.json;
-                    expect(res).to.have.status(HttpStatus.OK);
-
-                    requiredFields.verifyProduct(res.body);
-                    expect(res.body.name).to.equal('Blast Mini Pump');
-                    expect(res.body.variants[0].available).to.equal(false);
                 });
         });
 

--- a/test/products/getProductIT.js
+++ b/test/products/getProductIT.js
@@ -53,6 +53,22 @@ describe('magento getProduct', function() {
                 });
         });
 
+        // the product with SKU eqbisublp is intentionally marked as OUT_OF_STOCK on Magento
+        it('returns the stock information for a product', function() {
+            return chai.request(env.openwhiskEndpoint)
+                .get(env.productsPackage + 'getProductById')
+                .query({id: 'eqbisublp'})
+                .set('Cache-Control', 'no-cache')
+                .then(function (res) {
+                    expect(res).to.be.json;
+                    expect(res).to.have.status(HttpStatus.OK);
+
+                    requiredFields.verifyProduct(res.body);
+                    expect(res.body.name).to.equal('Blast Mini Pump');
+                    expect(res.body.variants[0].available).to.equal(false);
+                });
+        });
+
         it('returns a 404 error for a non existent product', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'getProductById')

--- a/test/products/getProductIT.js
+++ b/test/products/getProductIT.js
@@ -50,11 +50,12 @@ describe('magento getProduct', function() {
                     expect(res.body.id).to.equal(productId);
                     expect(res.body).to.have.own.property('categories');
                     expect(res.body).to.have.own.property('createdAt');
+                    expect(res.body.variants[0].available).to.equal(true);
                 });
         });
 
         // the product with SKU eqbisublp is intentionally marked as OUT_OF_STOCK on Magento
-        it('returns the stock information for a product', function() {
+        it('returns the stock information for an unavailable product', function() {
             return chai.request(env.openwhiskEndpoint)
                 .get(env.productsPackage + 'getProductById')
                 .query({id: 'eqbisublp'})

--- a/test/resources/sample-product-search-single-product.js
+++ b/test/resources/sample-product-search-single-product.js
@@ -12,42 +12,112 @@
  *
  ******************************************************************************/
 
-'use strict';
+"use strict";
 
-module.exports = {
-    "body": {
-        "data": {
-            "products": {
-                "total_count": 1,
-                "page_info": {
-                    "page_size": 1,
-                    "current_page": 1
+const simpleProductResponse = {
+    body: {
+        data: {
+            products: {
+                total_count: 1,
+                page_info: {
+                    page_size: 1,
+                    current_page: 1
                 },
-                "items": [
+                items: [
                     {
-                        "id": 1,
-                        "sku": "testSimpleProduct",
-                        "name": "Test Simple Product",
-                        "description": null,
-                        "created_at": "2018-06-12 11:15:02",
-                        "updated_at": "2018-06-12 11:15:02",
-                        "categories": [
+                        id: 1,
+                        sku: "testSimpleProduct",
+                        name: "Test Simple Product",
+                        description: null,
+                        created_at: "2018-06-12 11:15:02",
+                        updated_at: "2018-06-12 11:15:02",
+                        stock_status: "OUT_OF_STOCK",
+                        categories: [
                             {
-                                "id": 3
+                                id: 3
                             }
                         ],
-                        "price": {
-                            "regularPrice": {
-                                "amount": {
-                                    "value": 22,
-                                    "currency": "USD"
+                        price: {
+                            regularPrice: {
+                                amount: {
+                                    value: 22,
+                                    currency: "USD"
                                 }
                             }
                         },
-                        "image": null
+                        image: null
                     }
                 ]
             }
         }
     }
+};
+
+const productWithVariantsResponse = {
+    body: {
+        data: {
+            products: {
+                total_count: 1,
+                page_info: {
+                    page_size: 25,
+                    current_page: 1
+                },
+                items: [{
+                    id: 6,
+                    sku: "testConfigProduct",
+                    name: "Test Configurable Product",
+                    description: null,
+                    created_at: "2018-06-12 11:15:07",
+                    updated_at: "2018-06-12 11:15:12",
+                    categories: [
+                        {
+                            id: 3
+                        }
+                    ],
+                    price: {
+                        regularPrice: {
+                            amount: {
+                                value: 10,
+                                currency: "USD"
+                            }
+                        }
+                    },
+                    image: "no_selection",
+                    variants: [
+                        {
+                            product: {
+                                id: 3,
+                                sku: "testConfigProduct-red",
+                                name: "Test Red Configurable Product",
+                                description: null,
+                                created_at: "2018-06-12 11:15:05",
+                                updated_at: "2018-06-12 11:15:09",
+                                stock_status: "IN_STOCK",
+                                categories: [
+                                    {
+                                        id: 3
+                                    }
+                                ],
+                                price: {
+                                    regularPrice: {
+                                        amount: {
+                                            value: 10,
+                                            currency: "USD"
+                                        }
+                                    }
+                                },
+                                image: "no_selection",
+                                color: 4
+                            }
+                        }
+                    ]
+                }]
+            }
+        }
+    }
+};
+
+module.exports = {
+    simpleProductResponse,
+    productWithVariantsResponse
 };


### PR DESCRIPTION
## Description

Add the `stock_status` parameter to the GraphQL query and compute the `available` property of the product / variant based on the stock status.

## Related Issue
CIF-212

## Motivation and Context

The availability of the product is currently hardcoded to `true` (available)

## How Has This Been Tested?

Integration tests

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
