### PR TITLE
CIF-636 - [commerce-cif-magento] ITs failing on CircleCI

### DIFF
--- a/test/products/searchProductsIT.js
+++ b/test/products/searchProductsIT.js
@@ -133,7 +133,7 @@ describe('magento searchProducts', function() {
                     expect(product).to.have.own.property('createdAt');
 
                     expect(product.variants).to.have.lengthOf(15);
-                    expect(product.attributes).to.have.lengthOf(2);
+                    expect(product.attributes).to.have.lengthOf(4);
                     expect(product.attributes.find(o => {return o.id === 'summary'})).to.be.an('object');
                     expect(product.attributes.find(o => {return o.id === 'features'})).to.be.an('object');
 

--- a/test/resources/graphqlQueries.js
+++ b/test/resources/graphqlQueries.js
@@ -108,7 +108,7 @@ let attributesQuery = `{
 }`;
 
 let assetsQuery = `{
-    searchProducts(text: "meskwielt"){
+    searchProducts(text: "eqbisublp"){
         results {
             assets {
                 id


### PR DESCRIPTION
## Description

Update the ITs to work with the latest version of the data:
- update the SKU used by `graphQL` test, because the old SKU doesn't have images in the base product anymore.
- update the condition in failing `searchProductIT` because the attributes set changed (it now contains four atrributes instead of two

## Related Issue

CIF-636

## Motivation and Context

The ITs fail in CircleCI

## How Has This Been Tested?

The ITs now pass.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
