### PR TITLE
CIF-426 - Fix parents property for getCategoryBySlug

### DIFF
--- a/src/categories/CategoryMapper.js
+++ b/src/categories/CategoryMapper.js
@@ -60,10 +60,10 @@ class CategoryMapper {
             .build();
     }
 
-    static mapCategoryListToCategory(magentoResponse) {
+    static mapCategoryListToCategory(magentoResponse, ignoreCategoresWithLevelLowerThan) {
         if (magentoResponse && magentoResponse.items && magentoResponse.items.length > 0) {
             // Map only first category in result list
-            return CategoryMapper.mapCategory(magentoResponse.items[0]);
+            return CategoryMapper.mapCategory(magentoResponse.items[0], ignoreCategoresWithLevelLowerThan);
         }
         // If the result list is empty, return a 404
         throw { error: "No category found.", statusCode: 404 };

--- a/test/categories/getCategoriesIT.js
+++ b/test/categories/getCategoriesIT.js
@@ -167,6 +167,8 @@ describe('magento getCategories', function() {
                     expect(category.id).to.equal(MEN_SHIRTS_CATEGORY_ID);
                     expect(category).to.have.own.property('slug');
                     expect(category.slug).to.equal(MEN_SHORTS_CATEGORY_SLUG);
+                    expect(category).to.have.own.property('parents');
+                    expect(category.parents).to.have.lengthOf(1);
                 });
         });
 

--- a/test/categories/getCategoriesTest.js
+++ b/test/categories/getCategoriesTest.js
@@ -151,6 +151,8 @@ describe('Magento getCategories', () => {
                 assert.isNotEmpty(result.response);
                 assert.strictEqual(result.response.statusCode, 200);
                 assert.strictEqual(result.response.body.name, 'Shorts');
+                assert.isArray(result.response.body.parents);
+                assert.strictEqual(result.response.body.parents.length, 1);
             });
         });
 


### PR DESCRIPTION
## Description

The `parents` property is missing for `getCategoryBySlug` responses.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
