### PR TITLE
CIF-671 - Magento products search does not properly return graphQL er…

### DIFF
--- a/src/common/MagentoClientBase.js
+++ b/src/common/MagentoClientBase.js
@@ -16,6 +16,7 @@
 
 const respondWithServiceError = require('./web-response-utils').respondWithServiceError;
 const requestPromise = require('request-promise-native');
+const InvalidArgumentError = require('@adobe/commerce-cif-common/exception').InvalidArgumentError;
 
 /**
  * Base class for magento client. This should be extended for each implemented business domain api like customer, catalog,
@@ -81,6 +82,17 @@ class MagentoClientBase {
      */
     handleError(error) {
         return respondWithServiceError(error, this.args, Promise.resolve.bind(Promise), this.errorType);
+    }
+
+    handleGraphqlErrors(errors) {
+        let messages = errors.map(e => e.message);
+        let categories = errors.map(e => e.category);
+        let error = new InvalidArgumentError(messages.join(' | ')); // bad query
+        this.args['response'] = {
+            'error': error,
+            'errorType': categories.join(' | ')
+        };
+        return Promise.resolve(this.args);
     }
 
     /**

--- a/src/products/getProduct.js
+++ b/src/products/getProduct.js
@@ -59,6 +59,10 @@ function getProduct(args, param, filterKey) {
     }
 
     return request.then(response => {
+        if (response.body.errors) {
+            return client.handleGraphqlErrors(response.body.errors);
+        }
+
         const items = response.body.data.products.items;
         if (!items || items.length === 0) {
             return Promise.reject({

--- a/src/products/searchProducts.js
+++ b/src/products/searchProducts.js
@@ -68,7 +68,12 @@ function searchProducts(args) {
     } else {
         request = req(options);
     }
+    
     return request.then((response) => {
+        if (response.body.errors) {
+            return client.handleGraphqlErrors(response.body.errors);
+        }
+
         let imageUrlPrefix = `${args.MAGENTO_SCHEMA}://${args.MAGENTO_HOST}/${args.MAGENTO_MEDIA_PATH}`;
         let productMapper = new ProductMapper(imageUrlPrefix, args.GRAPHQL_PRODUCT_ATTRIBUTES);
         return client._handleSuccess(productMapper.mapGraphQlResponse(response.body), {}, response.statusCode);

--- a/test/products/getProductTest.js
+++ b/test/products/getProductTest.js
@@ -17,6 +17,7 @@
 const assert = require('chai').assert;
 const setup = require('../lib/setupTest').setup;
 const testData = require('../resources/sample-product-search-single-product');
+const errorData = require('../resources/sample-graphql-errors');
 const config = require('../lib/config').config;
 const sinon = require('sinon');
 
@@ -140,6 +141,17 @@ describe('magento getProductById', () => {
                 .then(result => {
                     assert.isTrue(consoleSpy.withArgs('BACKEND-CALL').calledOnce);
                     assert.isDefined(result.response.body); 
+                });
+        });
+
+        it('forwards graphQL error messages in CIF responses', () => {
+            return this.prepareResolve(errorData)
+                .execute(Object.assign({
+                    'id': 'testSimpleProduct'
+                }, config))
+                .then(result => {
+                    assert.strictEqual(result.response.error.name, 'InvalidArgumentError');
+                    assert.strictEqual(result.response.error.message, 'Cannot query field "whatever" on type "ProductInterface". | Cannot query field "whatever" on type "SimpleProduct".');
                 });
         });
     });

--- a/test/products/searchProductsTest.js
+++ b/test/products/searchProductsTest.js
@@ -19,6 +19,7 @@ const setup = require('../lib/setupTest').setup;
 const config = require('../lib/config').config;
 const sinon = require('sinon');
 const sampleProductSearch = require('../resources/sample-product-search');
+const errorData = require('../resources/sample-graphql-errors');
 
 describe('magento searchProducts', () => {
 
@@ -94,6 +95,16 @@ describe('magento searchProducts', () => {
             });
         });
 
+        it('forwards graphQL error messages in CIF responses', () => {
+            return this.prepareResolve(errorData)
+                .execute(Object.assign({
+                    'text': 'shirt'
+                }, config))
+                .then(result => {
+                    assert.strictEqual(result.response.error.name, 'InvalidArgumentError');
+                    assert.strictEqual(result.response.error.message, 'Cannot query field "whatever" on type "ProductInterface". | Cannot query field "whatever" on type "SimpleProduct".');
+                });
+        });
     });
 
 });

--- a/test/resources/sample-graphql-errors.js
+++ b/test/resources/sample-graphql-errors.js
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ *
+ *    Copyright 2018 Adobe. All rights reserved.
+ *    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License. You may obtain a copy
+ *    of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software distributed under
+ *    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *    OF ANY KIND, either express or implied. See the License for the specific language
+ *    governing permissions and limitations under the License.
+ *
+ ******************************************************************************/
+
+'use strict';
+
+module.exports = {
+    "body": {
+        "errors": [
+            {
+                "message": "Cannot query field \"whatever\" on type \"ProductInterface\".",
+                "category": "graphql"
+            },
+            {
+                "message": "Cannot query field \"whatever\" on type \"SimpleProduct\".",
+                "category": "graphql",
+            }
+        ]
+    }
+};


### PR DESCRIPTION
…ror messages

- added handling of graphQL error messages

## Description

The products search implementation for Magento does not properly extract and forward graphQL error messages, making it hard to find out what happens when a problem occurs.

## Related Issue

CIF-671

## How Has This Been Tested?

Added unit tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code passes the code style as defined by ESLint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
