### PR TITLE
CIF-731 - Fix CIF products search with Magento GraphQL 2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4402,7 +4402,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }

--- a/src/products/ProductMapper.js
+++ b/src/products/ProductMapper.js
@@ -78,8 +78,8 @@ class ProductMapper {
      */
     _mapProductData(p, product) {
 
-        if (product.description) {
-            p.description = product.description;
+        if (product.description && product.description.html) {
+            p.description = product.description.html;
         }
 
         if (product.created_at) {
@@ -90,9 +90,9 @@ class ProductMapper {
             p.lastModifiedAt = formatDate(product.updated_at);
         }
         
-        if (product.image) {
+        if (product.image && product.image.url) {
             p.assets = [
-                this._mapAsset(product.image)
+                this._mapAsset(product.image.url)
             ];
         }
         

--- a/src/products/searchProducts.graphql
+++ b/src/products/searchProducts.graphql
@@ -36,7 +36,9 @@
           name
           url_key
           stock_status
-          description
+          description {
+            html
+          }
           created_at
           updated_at
           {{#each attributes}}
@@ -54,7 +56,9 @@
               }
             }
           }
-          image
+          image {
+            url
+          }
           ... on ConfigurableProduct {
             configurable_options {
               attribute_code
@@ -71,7 +75,9 @@
                 name
                 url_key
                 stock_status
-                description
+                description {
+                  html
+                }
                 created_at
                 updated_at
                 categories {
@@ -85,7 +91,9 @@
                     }
                   }
                 }
-                image
+                image {
+                  url
+                }
                 {{#each attributes}}
                 {{this}}
                 {{/each}}

--- a/test/products/ProductMapperTest.js
+++ b/test/products/ProductMapperTest.js
@@ -175,7 +175,7 @@ describe('Magento ProductMapper', () => {
                 assert.strictEqual(product.id, magentoProduct.sku);
                 assert.strictEqual(product.masterVariantId, magentoFirstVariant.sku);
                 assert.strictEqual(product.name, magentoProduct.name);
-                assert.strictEqual(product.description, magentoFirstVariant.description);
+                assert.strictEqual(product.description, magentoFirstVariant.description.html);
                 assert.strictEqual(product.createdAt, formatDate(magentoProduct.created_at));
                 assert.strictEqual(product.lastModifiedAt, formatDate(magentoProduct.updated_at));
                 assert.lengthOf(product.variants, magentoProduct.variants.length);

--- a/test/resources/searchProductsBySku.json
+++ b/test/resources/searchProductsBySku.json
@@ -12,7 +12,9 @@
           "sku": "meskwielt",
           "name": "El Gordo Down Jacket",
           "url_key": "el-gordo-down-jacket",
-          "description": null,
+          "description": {
+            "html": null
+          },
           "created_at": "2018-06-21 12:52:09",
           "updated_at": "2018-06-21 12:52:09",
           "summary": "<p>With bigger channels and more fill, this extra toasty jacket is ideal as a midlayer or stand-alone in cold climes.</p>\n",
@@ -31,7 +33,9 @@
               }
             }
           },
-          "image": "/e/l/el_gordo_green.jpg",
+          "image": {
+            "url": "/e/l/el_gordo_green.jpg"
+          },
           "options_container": "container2",
           "configurable_options": [
             {
@@ -86,7 +90,9 @@
                 "sku": "meskwielt-Purple-XS",
                 "name": "meskwielt-Purple-XS",
                 "url_key": "meskwielt-purple-xs",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -103,7 +109,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_purple.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_purple.jpg"
+                },
                 "color": 42,
                 "size": 9,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -115,7 +123,9 @@
                 "id": 708,
                 "sku": "meskwielt-Purple-S",
                 "name": "meskwielt-Purple-S",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -131,7 +141,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_purple.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_purple.jpg"
+                },
                 "color": 42,
                 "size": 6,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -143,7 +155,9 @@
                 "id": 707,
                 "sku": "meskwielt-Purple-M",
                 "name": "meskwielt-Purple-M",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -159,7 +173,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_purple.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_purple.jpg"
+                },
                 "color": 42,
                 "size": 7,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -171,7 +187,9 @@
                 "id": 706,
                 "sku": "meskwielt-Purple-L",
                 "name": "meskwielt-Purple-L",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -187,7 +205,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_purple.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_purple.jpg"
+                },
                 "color": 42,
                 "size": 5,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -199,7 +219,9 @@
                 "id": 709,
                 "sku": "meskwielt-Purple-XL",
                 "name": "meskwielt-Purple-XL",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -215,7 +237,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_purple.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_purple.jpg"
+                },
                 "color": 42,
                 "size": 8,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -227,7 +251,9 @@
                 "id": 705,
                 "sku": "meskwielt-Green-XS",
                 "name": "meskwielt-Green-XS",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -243,7 +269,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_green.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_green.jpg"
+                },
                 "color": 38,
                 "size": 9,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -255,7 +283,9 @@
                 "id": 703,
                 "sku": "meskwielt-Green-S",
                 "name": "meskwielt-Green-S",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -271,7 +301,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_green.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_green.jpg"
+                },
                 "color": 38,
                 "size": 6,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -283,7 +315,9 @@
                 "id": 702,
                 "sku": "meskwielt-Green-M",
                 "name": "meskwielt-Green-M",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -299,7 +333,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_green.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_green.jpg"
+                },
                 "color": 38,
                 "size": 7,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -311,7 +347,9 @@
                 "id": 701,
                 "sku": "meskwielt-Green-L",
                 "name": "meskwielt-Green-L",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -327,7 +365,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_green.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_green.jpg"
+                },
                 "color": 38,
                 "size": 5,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -339,7 +379,9 @@
                 "id": 704,
                 "sku": "meskwielt-Green-XL",
                 "name": "meskwielt-Green-XL",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -355,7 +397,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_green.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_green.jpg"
+                },
                 "color": 38,
                 "size": 8,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -367,7 +411,9 @@
                 "id": 715,
                 "sku": "meskwielt-Red-XS",
                 "name": "meskwielt-Red-XS",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -383,7 +429,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_red.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_red.jpg"
+                },
                 "color": 39,
                 "size": 9,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -395,7 +443,9 @@
                 "id": 713,
                 "sku": "meskwielt-Red-S",
                 "name": "meskwielt-Red-S",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -411,7 +461,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_red.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_red.jpg"
+                },
                 "color": 39,
                 "size": 6,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -423,7 +475,9 @@
                 "id": 712,
                 "sku": "meskwielt-Red-M",
                 "name": "meskwielt-Red-M",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -439,7 +493,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_red.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_red.jpg"
+                },
                 "color": 39,
                 "size": 7,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -451,7 +507,9 @@
                 "id": 711,
                 "sku": "meskwielt-Red-L",
                 "name": "meskwielt-Red-L",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -467,7 +525,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_red.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_red.jpg"
+                },
                 "color": 39,
                 "size": 5,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",
@@ -479,7 +539,9 @@
                 "id": 714,
                 "sku": "meskwielt-Red-XL",
                 "name": "meskwielt-Red-XL",
-                "description": null,
+                "description": {
+                  "html": null
+                },
                 "created_at": "2018-06-21 12:52:09",
                 "updated_at": "2018-06-21 12:52:09",
                 "categories": [
@@ -495,7 +557,9 @@
                     }
                   }
                 },
-                "image": "/e/l/el_gordo_red.jpg",
+                "image": {
+                  "url": "/e/l/el_gordo_red.jpg"
+                },
                 "color": 39,
                 "size": 8,
                 "features": "<p><ul>\n<li>Sharp-looking, ripstop polyester shell, with a waterproof finish, blocks the wind and resists tears and abrasion</li>\n<li>Finer details include top-quality 800-fill-power goose down, a quilted-through construction, nylon-bound elastic cuffs and a drawcord hem</li>\n<li>Includes 2 zip hand pockets and 1 interior zip-secure pocket; removable hood</li>\n</ul>\n</p>",

--- a/test/resources/searchProductsWithPaging.json
+++ b/test/resources/searchProductsWithPaging.json
@@ -11,7 +11,9 @@
           "id": 153,
           "sku": "meotwipot",
           "name": "Portland Hooded Jacket",
-          "description": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>",
+          "description": {
+            "html": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>"
+          },
           "created_at": "2018-06-05 10:58:17",
           "updated_at": "2018-06-05 10:58:17",
           "categories": [
@@ -27,7 +29,9 @@
               }
             }
           },
-          "image": "/p/o/portland.jpg",
+          "image": {
+            "url": "/p/o/portland.jpg"
+          },
           "configurable_options": [
             {
               "attribute_code": "size",
@@ -58,7 +62,9 @@
                 "id": 156,
                 "sku": "meotwipot-S",
                 "name": "meotwipot-S",
-                "description": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>",
+                "description": {
+                  "html": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -74,7 +80,9 @@
                     }
                   }
                 },
-                "image": "/p/o/portland.jpg",
+                "image": {
+                  "url": "/p/o/portland.jpg"
+                },
                 "color": 5,
                 "size": 15
               }
@@ -84,7 +92,9 @@
                 "id": 157,
                 "sku": "meotwipot-XL",
                 "name": "meotwipot-XL",
-                "description": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>",
+                "description": {
+                  "html": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -100,7 +110,9 @@
                     }
                   }
                 },
-                "image": "/p/o/portland.jpg",
+                "image": {
+                  "url": "/p/o/portland.jpg"
+                },
                 "color": 5,
                 "size": 16
               }
@@ -110,7 +122,9 @@
                 "id": 154,
                 "sku": "meotwipot-L",
                 "name": "meotwipot-L",
-                "description": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>",
+                "description": {
+                  "html": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -126,7 +140,9 @@
                     }
                   }
                 },
-                "image": "/p/o/portland.jpg",
+                "image": {
+                  "url": "/p/o/portland.jpg"
+                },
                 "color": 5,
                 "size": 13
               }
@@ -136,7 +152,9 @@
                 "id": 155,
                 "sku": "meotwipot-M",
                 "name": "meotwipot-M",
-                "description": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>",
+                "description": {
+                  "html": "<p>The Portland Hooded Jacket takes you from the office to the airport in style. \"features=</p>\n<ul>\n<li>Cotton canvas exterior is lined with warm polyester fleece to take the chill out of a winter day</li>\n<li>Flip up the hood for protection against cool temperatures</li>\n<li>Full-zip front allows easy on and off; chin guard protects your skin</li>\n</ul>\n<p>\"</p>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -152,7 +170,9 @@
                     }
                   }
                 },
-                "image": "/p/o/portland.jpg",
+                "image": {
+                  "url": "/p/o/portland.jpg"
+                },
                 "color": 5,
                 "size": 14
               }
@@ -163,7 +183,9 @@
           "id": 158,
           "sku": "meotwislt",
           "name": "Slopeside Coat",
-          "description": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>",
+          "description": {
+            "html": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>"
+          },
           "created_at": "2018-06-05 10:58:17",
           "updated_at": "2018-06-05 10:58:17",
           "categories": [
@@ -179,7 +201,9 @@
               }
             }
           },
-          "image": "/s/l/slopeside.jpg",
+          "image": {
+            "url": "/s/l/slopeside.jpg"
+          },
           "configurable_options": [
             {
               "attribute_code": "size",
@@ -214,7 +238,9 @@
                 "id": 163,
                 "sku": "meotwislt-XS",
                 "name": "meotwislt-XS",
-                "description": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>",
+                "description": {
+                  "html": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -230,7 +256,9 @@
                     }
                   }
                 },
-                "image": "/s/l/slopeside.jpg",
+                "image": {
+                  "url": "/s/l/slopeside.jpg"
+                },
                 "color": 5,
                 "size": 17
               }
@@ -240,7 +268,9 @@
                 "id": 161,
                 "sku": "meotwislt-S",
                 "name": "meotwislt-S",
-                "description": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>",
+                "description": {
+                  "html": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -256,7 +286,9 @@
                     }
                   }
                 },
-                "image": "/s/l/slopeside.jpg",
+                "image": {
+                  "url": "/s/l/slopeside.jpg"
+                },
                 "color": 5,
                 "size": 15
               }
@@ -266,7 +298,9 @@
                 "id": 162,
                 "sku": "meotwislt-XL",
                 "name": "meotwislt-XL",
-                "description": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>",
+                "description": {
+                  "html": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -282,7 +316,9 @@
                     }
                   }
                 },
-                "image": "/s/l/slopeside.jpg",
+                "image": {
+                  "url": "/s/l/slopeside.jpg"
+                },
                 "color": 5,
                 "size": 16
               }
@@ -292,7 +328,9 @@
                 "id": 159,
                 "sku": "meotwislt-L",
                 "name": "meotwislt-L",
-                "description": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>",
+                "description": {
+                  "html": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -308,7 +346,9 @@
                     }
                   }
                 },
-                "image": "/s/l/slopeside.jpg",
+                "image": {
+                  "url": "/s/l/slopeside.jpg"
+                },
                 "color": 5,
                 "size": 13
               }
@@ -318,7 +358,9 @@
                 "id": 160,
                 "sku": "meotwislt-M",
                 "name": "meotwislt-M",
-                "description": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>",
+                "description": {
+                  "html": "<p>4-in-1 jacket creates options for changing conditions. Jacket sports a waterproof, breathable shell and an insulated, reversible liner jacket. \"features=</p>\n<ul>\n<li>Wear the shell jacket and zip-in liner jacket together for maximum protection or wear either piece on its own as weather conditions warrant; liner is reversible</li>\n<li>Quilted liner jacket uses polyfiber insulation to keep you warm without inhibiting mobility</li>\n<li>Liner jacket features zippered handwarmer pockets and an internal security pocket\"</li>\n</ul>"
+                },
                 "created_at": "2018-06-05 10:58:17",
                 "updated_at": "2018-06-05 10:58:17",
                 "categories": [
@@ -334,7 +376,9 @@
                     }
                   }
                 },
-                "image": "/s/l/slopeside.jpg",
+                "image": {
+                  "url": "/s/l/slopeside.jpg"
+                },
                 "color": 5,
                 "size": 14
               }


### PR DESCRIPTION
Magento 2.3.1 introduces some GraphQL backwards incompatible changes compared to 2.3.0.

## Description
Integration tests for this PR will only pass after we upgraded the Magento instance to 2.3.1. I tested the changes locally with an already upgraded instance.

<!--- Describe your changes in detail -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code passes the code style as defined by ESLint.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
